### PR TITLE
Implement P.collect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,7 @@ target/
 out/
 .DS_STORE
 *.iml
-.idea
+.idea/
+.bloop/
+.metals/
+.vscode/

--- a/fastparse/src/fastparse/internal/MacroImpls.scala
+++ b/fastparse/src/fastparse/internal/MacroImpls.scala
@@ -735,5 +735,4 @@ object MacroImpls {
                          ctx: c.Expr[ParsingRun[_]]): c.Expr[ParsingRun[R]] = {
     MacroImpls.parsedSequence0[T, V, R](c)(other, true)(s, None, ctx)
   }
-
 }

--- a/fastparse/src/fastparse/internal/MacroImpls.scala
+++ b/fastparse/src/fastparse/internal/MacroImpls.scala
@@ -160,6 +160,25 @@ object MacroImpls {
     }
   }
 
+  def collectMacro[T: c.WeakTypeTag, V: c.WeakTypeTag]
+                  (c: Context)
+                  (f: c.Expr[PartialFunction[T, V]]): c.Expr[ParsingRun[V]] = {
+    import c.universe._
+
+    val lhs0 = c.prefix.asInstanceOf[c.Expr[EagerOps[T]]]
+    reify {
+      lhs0.splice.parse0 match {
+        case lhs =>
+          if (!lhs.isSuccess) lhs.asInstanceOf[ParsingRun[V]]
+          else {
+            val this2 = lhs.asInstanceOf[ParsingRun[V]]
+            val f2 = f.splice.andThen(v => this2.successValue = v)
+            f2.applyOrElse(this2.successValue.asInstanceOf[T], {_: T => this2.freshFailure()})
+            this2
+          }
+      }
+    }
+  }
 
   def flatMapXMacro[T: c.WeakTypeTag, V: c.WeakTypeTag]
                   (c: Context)

--- a/fastparse/src/fastparse/package.scala
+++ b/fastparse/src/fastparse/package.scala
@@ -177,6 +177,15 @@ package object fastparse {
       */
     def filter(f: T => Boolean)
               (implicit ctx: P[Any]): P[T] = macro MacroImpls.filterMacro[T]
+
+    /**
+      * Transforms the result of this parser using the given partial function,
+      * failing the parse if the partial function is not defined on the result
+      * of the current parser. This is eqivalent to 
+      * `.filter(f.isDefinedAt).map(f.apply)`
+      */
+    def collect[V](f: PartialFunction[T, V]): P[V] = macro MacroImpls.collectMacro[T, V]
+
     /**
       * Transforms the result of this parser using the given function into a
       * new parser which is applied (after whitespace). Useful for doing

--- a/fastparse/test/src/fastparse/ExampleTests.scala
+++ b/fastparse/test/src/fastparse/ExampleTests.scala
@@ -193,6 +193,14 @@ object ExampleTests extends TestSuite{
         val Parsed.Success(12, _) = parse("1100", binaryNum(_))
       }
 
+      test("collect"){
+        def binary[_: P] = P( ("0" | "1" ).rep.! )
+        def binaryNum[_: P] = P( binary.collect { case v if v.size % 2 == 0 => Integer.parseInt(v, 2)} )
+
+        val Parsed.Success("1100", _) = parse("1100", binary(_))
+        val Parsed.Failure(_, _, _) = parse("11001", binaryNum(_))
+      }
+
       test("flatMap"){
         def leftTag[_: P] = P( "<" ~ (!">" ~ AnyChar).rep(1).! ~ ">")
         def rightTag[_: P](s: String) = P( "</" ~ s.! ~ ">" )


### PR DESCRIPTION
Transforms the result of this parser using the given partial function, failing the parse if the partial function is not defined on the result of the current parser. This is eqivalent to `.filter(f.isDefinedAt).map(f.apply)`.