### PR TITLE
Make Failure extractor exhaustive

### DIFF
--- a/fastparse/src/fastparse/Parsed.scala
+++ b/fastparse/src/fastparse/Parsed.scala
@@ -95,10 +95,8 @@ object Parsed{
 
   object Failure{
     def apply(label: String, index: Int, extra: Extra) = new Failure(label, index, extra)
-    def unapply(x: Failure): Option[(String, Int, Extra)] = x match{
-      case f: Failure => Some((f.label, f.index, f.extra))
-      case _ => None
-    }
+    def unapply(f: Failure): Some[(String, Int, Extra)] =
+      Some((f.label, f.index, f.extra))
     def formatMsg(input: ParserInput, stack: List[(String, Int)], index: Int) = {
       "Expected " + Failure.formatStack(input, stack) +
       ", found " + Failure.formatTrailing(input, index)

--- a/fastparse/src/fastparse/Parsed.scala
+++ b/fastparse/src/fastparse/Parsed.scala
@@ -221,4 +221,3 @@ object Parsed{
     def longAggregateMsg = Failure.formatMsg(input, stack ++ Seq(groupAggregateString -> index), index)
   }
 }
-


### PR DESCRIPTION
This makes code like the following compile without an exhaustiveness warning:

```scala
parse(...) match {
  case Failure(err, index, extra) =>
    ...
  case Success(p, index) =>
    ...
}
```

Instead, one currently has to write:

```scala
parse(...) match {
  case f: Failure =>
    val Failure(err, index, extra) = f
    ...
  case Success(p, index) =>
    ...
}
```