### PR TITLE
fix css comment bug. 

### DIFF
--- a/cssparse/src/cssparse/CssParser.scala
+++ b/cssparse/src/cssparse/CssParser.scala
@@ -8,7 +8,7 @@ import fastparse.NoWhitespace._
 
 object CssTokensParser {
 
-  def comment[_: P] = P( "/*" ~/ (!"*/" ~ AnyChar).rep ~/ "*/")
+  def comment[_: P] = P( "/*" ~ (!"*/" ~ AnyChar).rep ~ "*/")
 
   def newline[_: P] = P( "\n" | "\r\n" | "\r" | "\f")
 

--- a/cssparse/test/src/cssparse/CssTests.scala
+++ b/cssparse/test/src/cssparse/CssTests.scala
@@ -191,6 +191,30 @@ object CssTests extends TestSuite {
                 UnicodeRangeToken("0025", "00FF"), DelimToken(","), UnicodeRangeToken("4??", "4??")), false))))))))))
 
       }
+
+      // https://github.com/com-lihaoyi/fastparse/issues/255
+      test("issue-#255: comments at the end of a block"){
+        val Parsed.Success(value2, index2) = parse(
+          """
+            |p {
+            |  font-family: sans-serif;
+            |  color: red;
+            |  /* test comment */
+            |}
+            |
+          """.stripMargin, CssRulesParser.ruleList(_))
+
+        assert(
+          value2 ==
+            RuleList(Seq(
+              QualifiedRule(
+                Left(ElementSelector("p")),
+                DeclarationList(Seq(
+                  Left(Declaration("font-family", Seq(IdentToken("sans-serif")), false)),
+                  Left(Declaration("color", Seq(IdentToken("red")), false))))))),
+          index2 == 80
+        )
+      }
     }
   }
 }


### PR DESCRIPTION
fixes https://github.com/com-lihaoyi/fastparse/issues/255

Enable backtracking on comments, otherwise the parser will error when the comment is last line in a block.