### PR TITLE
Make Whitespace a proper trait rather than function to avoid unwanted implicit conversions

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -205,7 +205,11 @@ trait CommonCrossModule extends CrossScalaModule with PublishModule {
   def platformSegment: String
   def millSourcePath = super.millSourcePath / os.up
   def sources = T.sources {
-    super.sources().flatMap{p => Seq(p, PathRef(p.path / os.up / s"${p.path.last}-$platformSegment")) }
+    super.sources()
+      .flatMap{p => Seq(p, PathRef(p.path / os.up / s"${p.path.last}-$platformSegment")) } ++
+      (if (scalaVersion() != scala211) {
+        Seq(PathRef(millSourcePath / "src-2.12+"))
+      } else Seq())
   }
 }
 trait CommonTestModule extends ScalaModule with TestModule.Utest{

--- a/fastparse/src-2/fastparse/internal/MacroImpls.scala
+++ b/fastparse/src-2/fastparse/internal/MacroImpls.scala
@@ -196,7 +196,7 @@ object MacroImpls {
   def flatMapMacro[T: c.WeakTypeTag, V: c.WeakTypeTag]
                   (c: Context)
                   (f: c.Expr[T => ParsingRun[V]])
-                  (whitespace: c.Expr[ParsingRun[Any] => ParsingRun[Unit]]): c.Expr[ParsingRun[V]] = {
+                  (whitespace: c.Expr[fastparse.Whitespace]): c.Expr[ParsingRun[V]] = {
     import c.universe._
 
     val lhs0 = c.prefix.asInstanceOf[c.Expr[EagerOps[T]]]
@@ -439,7 +439,7 @@ object MacroImpls {
                      (c: Context)
                      (rhs: c.Expr[ParsingRun[V]], cut: Boolean)
                      (s: c.Expr[Implicits.Sequencer[T, V, R]],
-                      whitespace: Option[c.Expr[ParsingRun[Any] => ParsingRun[Unit]]],
+                      whitespace: Option[c.Expr[fastparse.Whitespace]],
                       ctx: c.Expr[ParsingRun[_]]): c.Expr[ParsingRun[R]] = {
     import c.universe._
 
@@ -708,7 +708,7 @@ object MacroImpls {
                     (c: Context)
                     (other: c.Expr[ParsingRun[V]])
                     (s: c.Expr[Implicits.Sequencer[T, V, R]],
-                     whitespace: c.Expr[ParsingRun[Any] => ParsingRun[Unit]],
+                     whitespace: c.Expr[fastparse.Whitespace],
                      ctx: c.Expr[ParsingRun[_]]): c.Expr[ParsingRun[R]] = {
     MacroImpls.parsedSequence0[T, V, R](c)(other, false)(s, Some(whitespace), ctx)
   }
@@ -717,7 +717,7 @@ object MacroImpls {
                        (c: Context)
                        (other: c.Expr[ParsingRun[V]])
                        (s: c.Expr[Implicits.Sequencer[T, V, R]],
-                        whitespace: c.Expr[ParsingRun[Any] => ParsingRun[Unit]],
+                        whitespace: c.Expr[fastparse.Whitespace],
                         ctx: c.Expr[ParsingRun[_]]): c.Expr[ParsingRun[R]] = {
     MacroImpls.parsedSequence0[T, V, R](c)(other, true)(s, Some(whitespace), ctx)
   }

--- a/fastparse/src-2/fastparse/package.scala
+++ b/fastparse/src-2/fastparse/package.scala
@@ -21,6 +21,11 @@ package object fastparse extends fastparse.SharedPackageDefs {
 
   val P = ParsingRun
 
+  implicit def DiscardParserValue(p: P[_]): P[Unit] = {
+    p.successValue = ()
+    p.asInstanceOf[P[Unit]]
+  }
+
   /**
     * Parses an exact string value.
     */
@@ -50,7 +55,7 @@ package object fastparse extends fastparse.SharedPackageDefs {
       */
     def ~/[V, R](other: P[V])
                 (implicit s: Implicits.Sequencer[T, V, R],
-                 whitespace: P[Any] => P[Unit],
+                 whitespace: Whitespace,
                  ctx: P[_]): P[R] = macro MacroImpls.parsedSequenceCut[T, V, R]
 
     /**
@@ -60,7 +65,7 @@ package object fastparse extends fastparse.SharedPackageDefs {
       */
     def ~[V, R](other:  P[V])
                (implicit s: Implicits.Sequencer[T, V, R],
-                whitespace: P[Any] => P[Unit],
+                whitespace: Whitespace,
                 ctx: P[_]): P[R] = macro MacroImpls.parsedSequence[T, V, R]
 
     /**
@@ -113,7 +118,7 @@ package object fastparse extends fastparse.SharedPackageDefs {
       * you next want to parse an array, dictionary or string.
       */
     def flatMap[V](f: T => P[V])
-                  (implicit whitespace: P[Any] => P[Unit]): P[V] = macro MacroImpls.flatMapMacro[T, V]
+                  (implicit whitespace: Whitespace): P[V] = macro MacroImpls.flatMapMacro[T, V]
     /**
       * Transforms the result of this parser using the given function into a
       * new parser which is applied (without consuming whitespace). Useful for
@@ -163,7 +168,7 @@ package object fastparse extends fastparse.SharedPackageDefs {
       * index of the last run.
       */
     def rep[V](implicit repeater: Implicits.Repeater[T, V],
-               whitespace: P[_] => P[Unit],
+               whitespace: Whitespace,
                ctx: P[Any]): P[V] = macro MacroRepImpls.repXMacro1ws[T, V]
     /**
       * Repeat operator; runs the LHS parser at least `min` to at most `max`
@@ -179,7 +184,7 @@ package object fastparse extends fastparse.SharedPackageDefs {
                max: Int = Int.MaxValue,
                exactly: Int = -1)
               (implicit repeater: Implicits.Repeater[T, V],
-               whitespace: P[_] => P[Unit],
+               whitespace: Whitespace,
                ctx: P[Any]): P[V] =
       new RepImpls[T](parse0).rep[V](min, sep, max, exactly)
 
@@ -192,7 +197,7 @@ package object fastparse extends fastparse.SharedPackageDefs {
     def rep[V](min: Int,
                sep: => P[_])
               (implicit repeater: Implicits.Repeater[T, V],
-               whitespace: P[_] => P[Unit],
+               whitespace: Whitespace,
                ctx: P[Any]): P[V] =
       new RepImpls[T](parse0).rep[V](min, sep)
 
@@ -204,7 +209,7 @@ package object fastparse extends fastparse.SharedPackageDefs {
       */
     def rep[V](min: Int)
               (implicit repeater: Implicits.Repeater[T, V],
-               whitespace: P[_] => P[Unit],
+               whitespace: Whitespace,
                ctx: P[Any]): P[V] =
     macro MacroRepImpls.repXMacro2ws[T, V]
 

--- a/fastparse/src-3/fastparse/internal/MacroInlineImpls.scala
+++ b/fastparse/src-3/fastparse/internal/MacroInlineImpls.scala
@@ -135,7 +135,7 @@ object MacroInlineImpls {
 
   def parsedSequence0[T: Type, V: Type, R: Type](lhs: Expr[ParsingRun[T]], rhs: Expr[ParsingRun[V]], cut: Boolean)(
       s: Expr[Implicits.Sequencer[T, V, R]],
-      whitespace: Null | Expr[ParsingRun[Any] => ParsingRun[Unit]],
+      whitespace: Null | Expr[fastparse.Whitespace],
       ctx: Expr[ParsingRun[_]]
   )(using quotes: Quotes): Expr[ParsingRun[R]] = {
     import quotes.reflect.*
@@ -283,7 +283,7 @@ object MacroInlineImpls {
 
   inline def flatMapInline[T, V](
       lhs: ParsingRun[T]
-  )(inline f: T => ParsingRun[V])(ws: ParsingRun[Any] => ParsingRun[Unit]): ParsingRun[V] = {
+  )(inline f: T => ParsingRun[V])(ws: fastparse.Whitespace): ParsingRun[V] = {
     if (!lhs.isSuccess) lhs.asInstanceOf[ParsingRun[V]]
     else {
       val oldCapturing = lhs.noDropBuffer

--- a/fastparse/src-3/fastparse/internal/MacroRepImpls.scala
+++ b/fastparse/src-3/fastparse/internal/MacroRepImpls.scala
@@ -18,7 +18,7 @@ import scala.quoted.*
 object MacroRepImpls {
   def repXMacro0[T: Type, V: Type](
       lhs: Expr[ParsingRun[T]],
-      whitespace: Null | Expr[ParsingRun[_] => ParsingRun[Unit]],
+      whitespace: Null | Expr[fastparse.Whitespace],
       min: Null | Expr[Int],
   )(repeater: Expr[Implicits.Repeater[T, V]], ctx: Expr[ParsingRun[_]])(using quotes: Quotes): Expr[ParsingRun[V]] = {
     import quotes.reflect.*

--- a/fastparse/src/fastparse/Whitespace.scala
+++ b/fastparse/src/fastparse/Whitespace.scala
@@ -4,11 +4,16 @@ import fastparse._
 import fastparse.internal.Util
 
 import scala.annotation.{Annotation, switch, tailrec}
+
+
+trait Whitespace{
+  def apply(ctx: ParsingRun[_]): ParsingRun[Unit]
+}
 /**
   * No-op whitespace syntax that doesn't consume anything
   */
 object NoWhitespace {
-  implicit object noWhitespaceImplicit extends (ParsingRun[_] => ParsingRun[Unit]){
+  implicit object noWhitespaceImplicit extends Whitespace{
     def apply(ctx: ParsingRun[_]) = ctx.freshSuccessUnit()
   }
 }
@@ -18,15 +23,17 @@ object NoWhitespace {
   * characters.
   */
 object SingleLineWhitespace {
-  implicit val whitespace: ParsingRun[_] => ParsingRun[Unit] = {implicit ctx: ParsingRun[_] =>
-    var index = ctx.index
-    val input = ctx.input
-    
-    while(
-      input.isReachable(index) &&
-      (input(index) match{ case ' ' | '\t' => true case _ => false})
-    ) index += 1
-    ctx.freshSuccessUnit(index = index)
+  implicit object whitespace extends Whitespace {
+    def apply(ctx: ParsingRun[_]) = {
+      var index = ctx.index
+      val input = ctx.input
+
+      while(
+        input.isReachable(index) &&
+        (input(index) match{ case ' ' | '\t' => true case _ => false})
+      ) index += 1
+      ctx.freshSuccessUnit(index = index)
+    }
   }
 }
 /**
@@ -34,15 +41,17 @@ object SingleLineWhitespace {
   * "\r" and "\n" whitespace characters.
   */
 object MultiLineWhitespace {
-  implicit val whitespace: ParsingRun[_] => ParsingRun[Unit] = {implicit ctx: ParsingRun[_] =>
-    var index = ctx.index
-    val input = ctx.input
+  implicit object whitespace extends Whitespace {
+    def apply(ctx: ParsingRun[_]) = {
+      var index = ctx.index
+      val input = ctx.input
 
-    while(
-      input.isReachable(index) &&
-        (input(index) match{ case ' ' | '\t' | '\r' | '\n' => true case _ => false})
-    ) index += 1
-    ctx.freshSuccessUnit(index = index)
+      while(
+        input.isReachable(index) &&
+          (input(index) match{ case ' ' | '\t' | '\r' | '\n' => true case _ => false})
+      ) index += 1
+      ctx.freshSuccessUnit(index = index)
+    }
   }
 }
 
@@ -51,24 +60,26 @@ object MultiLineWhitespace {
   * programming languages such as Bash, Ruby, or Python
   */
 object ScriptWhitespace{
-  implicit val whitespace: ParsingRun[_] => ParsingRun[Unit] = {implicit ctx: ParsingRun[_] =>
-    val input = ctx.input
-    @tailrec def rec(current: Int, state: Int): ParsingRun[Unit] = {
-      if (!input.isReachable(current)) ctx.freshSuccessUnit(current)
-      else {
-        val currentChar = input(current)
-        (state: @switch) match{
-          case 0 =>
-            (currentChar: @switch) match{
-              case ' ' | '\t' | '\n' | '\r' => rec(current + 1, state)
-              case '#' => rec(current + 1, state = 1)
-              case _ => ctx.freshSuccessUnit(current)
-            }
-          case 1 => rec(current + 1, state = if (currentChar == '\n') 0 else state)
+  implicit object whitespace extends Whitespace {
+    def apply(ctx: ParsingRun[_]) = {
+      val input = ctx.input
+      @tailrec def rec(current: Int, state: Int): ParsingRun[Unit] = {
+        if (!input.isReachable(current)) ctx.freshSuccessUnit(current)
+        else {
+          val currentChar = input(current)
+          (state: @switch) match{
+            case 0 =>
+              (currentChar: @switch) match{
+                case ' ' | '\t' | '\n' | '\r' => rec(current + 1, state)
+                case '#' => rec(current + 1, state = 1)
+                case _ => ctx.freshSuccessUnit(current)
+              }
+            case 1 => rec(current + 1, state = if (currentChar == '\n') 0 else state)
+          }
         }
       }
+      rec(current = ctx.index, state = 0)
     }
-    rec(current = ctx.index, state = 0)
   }
 }
 
@@ -78,47 +89,49 @@ object ScriptWhitespace{
   * in the Java programming language
   */
 object JavaWhitespace{
-  implicit val whitespace: ParsingRun[_] => ParsingRun[Unit] = {implicit ctx: ParsingRun[_] =>
-    val input = ctx.input
-    val startIndex = ctx.index
-    @tailrec def rec(current: Int, state: Int): ParsingRun[Unit] = {
-      if (!input.isReachable(current)) {
-        if (state == 0 || state == 1) ctx.freshSuccessUnit(current)
-        else if(state == 2)  ctx.freshSuccessUnit(current - 1)
-        else {
-          ctx.cut = true
-          val res = ctx.freshFailure(current)
-          if (ctx.verboseFailures) ctx.setMsg(startIndex, () => Util.literalize("*/"))
-          res
-        }
-      } else {
-        val currentChar = input(current)
-        (state: @switch) match{
-          case 0 =>
-            (currentChar: @switch) match{
-              case ' ' | '\t' | '\n' | '\r' => rec(current + 1, state)
-              case '/' => rec(current + 1, state = 2)
-              case _ => ctx.freshSuccessUnit(current)
-            }
-          case 1 => rec(current + 1, state = if (currentChar == '\n') 0 else state)
-          case 2 =>
-            (currentChar: @switch) match{
-              case '/' => rec(current + 1, state = 1)
-              case '*' => rec(current + 1, state = 3)
-              case _ => ctx.freshSuccessUnit(current - 1)
-            }
-          case 3 => rec(current + 1, state = if (currentChar == '*') 4 else state)
-          case 4 =>
-            (currentChar: @switch) match{
-              case '/' => rec(current + 1, state = 0)
-              case '*' => rec(current + 1, state = 4)
-              case _ => rec(current + 1, state = 3)
-            }
-//            rec(current + 1, state = if (currentChar == '/') 0 else 3)
+  implicit object whitespace extends Whitespace {
+    def apply(ctx: ParsingRun[_]) = {
+      val input = ctx.input
+      val startIndex = ctx.index
+      @tailrec def rec(current: Int, state: Int): ParsingRun[Unit] = {
+        if (!input.isReachable(current)) {
+          if (state == 0 || state == 1) ctx.freshSuccessUnit(current)
+          else if(state == 2)  ctx.freshSuccessUnit(current - 1)
+          else {
+            ctx.cut = true
+            val res = ctx.freshFailure(current)
+            if (ctx.verboseFailures) ctx.setMsg(startIndex, () => Util.literalize("*/"))
+            res
+          }
+        } else {
+          val currentChar = input(current)
+          (state: @switch) match{
+            case 0 =>
+              (currentChar: @switch) match{
+                case ' ' | '\t' | '\n' | '\r' => rec(current + 1, state)
+                case '/' => rec(current + 1, state = 2)
+                case _ => ctx.freshSuccessUnit(current)
+              }
+            case 1 => rec(current + 1, state = if (currentChar == '\n') 0 else state)
+            case 2 =>
+              (currentChar: @switch) match{
+                case '/' => rec(current + 1, state = 1)
+                case '*' => rec(current + 1, state = 3)
+                case _ => ctx.freshSuccessUnit(current - 1)
+              }
+            case 3 => rec(current + 1, state = if (currentChar == '*') 4 else state)
+            case 4 =>
+              (currentChar: @switch) match{
+                case '/' => rec(current + 1, state = 0)
+                case '*' => rec(current + 1, state = 4)
+                case _ => rec(current + 1, state = 3)
+              }
+  //            rec(current + 1, state = if (currentChar == '/') 0 else 3)
+          }
         }
       }
+      rec(current = ctx.index, state = 0)
     }
-    rec(current = ctx.index, state = 0)
   }
 }
 
@@ -128,47 +141,49 @@ object JavaWhitespace{
   * case in the Jsonnet programming language
   */
 object JsonnetWhitespace{
-  implicit val whitespace: ParsingRun[_] => ParsingRun[Unit] = {implicit ctx: ParsingRun[_] =>
-    val input = ctx.input
-    val startIndex = ctx.index
-    @tailrec def rec(current: Int, state: Int): ParsingRun[Unit] = {
-      if (!input.isReachable(current)) {
-        if (state == 0 || state == 1) ctx.freshSuccessUnit(current)
-        else if(state == 2)  ctx.freshSuccessUnit(current - 1)
-        else {
-          ctx.cut = true
-          val res = ctx.freshFailure(current)
-          if (ctx.verboseFailures) ctx.setMsg(startIndex, () => Util.literalize("*/"))
-          res
-        }
-      } else {
-        val currentChar = input(current)
-        (state: @switch) match{
-          case 0 =>
-            (currentChar: @switch) match{
-              case ' ' | '\t' | '\n' | '\r' => rec(current + 1, state)
-              case '#' => rec(current + 1, state = 1)
-              case '/' => rec(current + 1, state = 2)
-              case _ => ctx.freshSuccessUnit(current)
-            }
-          case 1 => rec(current + 1, state = if (currentChar == '\n') 0 else state)
-          case 2 =>
-            (currentChar: @switch) match{
-              case '/' => rec(current + 1, state = 1)
-              case '*' => rec(current + 1, state = 3)
-              case _ => ctx.freshSuccessUnit(current - 1)
-            }
-          case 3 => rec(current + 1, state = if (currentChar == '*') 4 else state)
-          case 4 =>
-            (currentChar: @switch) match{
-              case '/' => rec(current + 1, state = 0)
-              case '*' => rec(current + 1, state = 4)
-              case _ => rec(current + 1, state = 3)
-            }
+  implicit object whitespace extends Whitespace {
+    def apply(ctx: ParsingRun[_]) = {
+      val input = ctx.input
+      val startIndex = ctx.index
+      @tailrec def rec(current: Int, state: Int): ParsingRun[Unit] = {
+        if (!input.isReachable(current)) {
+          if (state == 0 || state == 1) ctx.freshSuccessUnit(current)
+          else if(state == 2)  ctx.freshSuccessUnit(current - 1)
+          else {
+            ctx.cut = true
+            val res = ctx.freshFailure(current)
+            if (ctx.verboseFailures) ctx.setMsg(startIndex, () => Util.literalize("*/"))
+            res
+          }
+        } else {
+          val currentChar = input(current)
+          (state: @switch) match{
+            case 0 =>
+              (currentChar: @switch) match{
+                case ' ' | '\t' | '\n' | '\r' => rec(current + 1, state)
+                case '#' => rec(current + 1, state = 1)
+                case '/' => rec(current + 1, state = 2)
+                case _ => ctx.freshSuccessUnit(current)
+              }
+            case 1 => rec(current + 1, state = if (currentChar == '\n') 0 else state)
+            case 2 =>
+              (currentChar: @switch) match{
+                case '/' => rec(current + 1, state = 1)
+                case '*' => rec(current + 1, state = 3)
+                case _ => ctx.freshSuccessUnit(current - 1)
+              }
+            case 3 => rec(current + 1, state = if (currentChar == '*') 4 else state)
+            case 4 =>
+              (currentChar: @switch) match{
+                case '/' => rec(current + 1, state = 0)
+                case '*' => rec(current + 1, state = 4)
+                case _ => rec(current + 1, state = 3)
+              }
+          }
         }
       }
+      rec(current = ctx.index, state = 0)
     }
-    rec(current = ctx.index, state = 0)
   }
 }
 
@@ -178,55 +193,57 @@ object JsonnetWhitespace{
   * in the Scala programming language
   */
 object ScalaWhitespace {
-  implicit val whitespace: ParsingRun[_] => ParsingRun[Unit] = {implicit ctx: ParsingRun[_] =>
-    val input = ctx.input
-    val startIndex = ctx.index
-    @tailrec def rec(current: Int, state: Int, nesting: Int): ParsingRun[Unit] = {
-      if (!input.isReachable(current)) {
-        if (state == 0 || state == 1) ctx.freshSuccessUnit(current)
-        else if(state == 2 && nesting == 0) ctx.freshSuccessUnit(current - 1)
-        else {
-          ctx.cut = true
-          val res = ctx.freshFailure(current)
-          if (ctx.verboseFailures) ctx.setMsg(startIndex, () => Util.literalize("*/"))
-          res
-        }
-      } else {
-        val currentChar = input(current)
-        (state: @switch) match{
-          case 0 =>
-            (currentChar: @switch) match{
-              case ' ' | '\t' | '\n' | '\r' => rec(current + 1, state, 0)
-              case '/' => rec(current + 1, state = 2, 0)
-              case _ => ctx.freshSuccessUnit(current)
-            }
-          case 1 => rec(current + 1, state = if (currentChar == '\n') 0 else state, 0)
-          case 2 =>
-            (currentChar: @switch) match{
-              case '/' =>
-                if (nesting == 0) rec(current + 1, state = 1, 0)
-                else rec(current + 1, state = 2, nesting)
-              case '*' => rec(current + 1, state = 3, nesting + 1)
-              case _ =>
-                if (nesting == 0) ctx.freshSuccessUnit(current - 1)
-                else rec(current + 1, state = 3, nesting)
-            }
-          case 3 =>
-            (currentChar: @switch) match{
-              case '/' => rec(current + 1, state = 2, nesting)
-              case '*' => rec(current + 1, state = 4 , nesting)
-              case _ => rec(current + 1, state = state, nesting)
-            }
-          case 4 =>
-            (currentChar: @switch) match{
-              case '/' => rec(current + 1, state = if (nesting == 1) 0 else 3 , nesting - 1)
-              case '*' => rec(current + 1, state = 4, nesting)
-              case _ => rec(current + 1, state = 3, nesting)
-            }
+  implicit object whitespace extends Whitespace {
+    def apply(ctx: ParsingRun[_]) = {
+      val input = ctx.input
+      val startIndex = ctx.index
+      @tailrec def rec(current: Int, state: Int, nesting: Int): ParsingRun[Unit] = {
+        if (!input.isReachable(current)) {
+          if (state == 0 || state == 1) ctx.freshSuccessUnit(current)
+          else if(state == 2 && nesting == 0) ctx.freshSuccessUnit(current - 1)
+          else {
+            ctx.cut = true
+            val res = ctx.freshFailure(current)
+            if (ctx.verboseFailures) ctx.setMsg(startIndex, () => Util.literalize("*/"))
+            res
+          }
+        } else {
+          val currentChar = input(current)
+          (state: @switch) match{
+            case 0 =>
+              (currentChar: @switch) match{
+                case ' ' | '\t' | '\n' | '\r' => rec(current + 1, state, 0)
+                case '/' => rec(current + 1, state = 2, 0)
+                case _ => ctx.freshSuccessUnit(current)
+              }
+            case 1 => rec(current + 1, state = if (currentChar == '\n') 0 else state, 0)
+            case 2 =>
+              (currentChar: @switch) match{
+                case '/' =>
+                  if (nesting == 0) rec(current + 1, state = 1, 0)
+                  else rec(current + 1, state = 2, nesting)
+                case '*' => rec(current + 1, state = 3, nesting + 1)
+                case _ =>
+                  if (nesting == 0) ctx.freshSuccessUnit(current - 1)
+                  else rec(current + 1, state = 3, nesting)
+              }
+            case 3 =>
+              (currentChar: @switch) match{
+                case '/' => rec(current + 1, state = 2, nesting)
+                case '*' => rec(current + 1, state = 4 , nesting)
+                case _ => rec(current + 1, state = state, nesting)
+              }
+            case 4 =>
+              (currentChar: @switch) match{
+                case '/' => rec(current + 1, state = if (nesting == 1) 0 else 3 , nesting - 1)
+                case '*' => rec(current + 1, state = 4, nesting)
+                case _ => rec(current + 1, state = 3, nesting)
+              }
+          }
         }
       }
+      rec(current = ctx.index, state = 0, nesting = 0)
     }
-    rec(current = ctx.index, state = 0, nesting = 0)
   }
 
 }

--- a/fastparse/src/fastparse/internal/RepImpls.scala
+++ b/fastparse/src/fastparse/internal/RepImpls.scala
@@ -131,7 +131,7 @@ class RepImpls[T](val parse0: () => ParsingRun[T]) extends AnyVal{
              max: Int = Int.MaxValue,
              exactly: Int = -1)
             (implicit repeater: Implicits.Repeater[T, V],
-             whitespace: ParsingRun[_] => ParsingRun[Unit],
+             whitespace: fastparse.Whitespace,
              ctx: ParsingRun[Any]): ParsingRun[V] = {
 
     val acc = repeater.initial
@@ -204,7 +204,7 @@ class RepImpls[T](val parse0: () => ParsingRun[T]) extends AnyVal{
   def rep[V](min: Int,
              sep: => ParsingRun[_])
             (implicit repeater: Implicits.Repeater[T, V],
-             whitespace: ParsingRun[_] => ParsingRun[Unit],
+             whitespace: fastparse.Whitespace,
              ctx: ParsingRun[Any]): ParsingRun[V] = {
 
     val acc = repeater.initial

--- a/fastparse/src/fastparse/internal/Util.scala
+++ b/fastparse/src/fastparse/internal/Util.scala
@@ -15,7 +15,7 @@ object Util {
     else if (rhs.value.isEmpty) lhs
     else Msgs(List(new Lazy(() => lhs.render + " ~ " + rhs.render)))
 
-  def consumeWhitespace[V](whitespace: ParsingRun[_] => ParsingRun[Unit], ctx: ParsingRun[Any]) = {
+  def consumeWhitespace[V](whitespace: fastparse.Whitespace, ctx: ParsingRun[Any]) = {
     val oldCapturing = ctx.noDropBuffer // completely disallow dropBuffer
     ctx.noDropBuffer = true
     whitespace(ctx)

--- a/fastparse/test/src-2.12+/fastparse/CustomWhitespaceMathTests.scala
+++ b/fastparse/test/src-2.12+/fastparse/CustomWhitespaceMathTests.scala
@@ -4,11 +4,13 @@ import fastparse._
 import utest._
 
 /**
-  * Same as MathTests, but demonstrating the use of whitespace
-  */
+ * Same as MathTests, but demonstrating the use of whitespace
+ */
 object CustomWhitespaceMathTests extends TestSuite{
-  implicit val whitespace: ParsingRun[_] => P[Unit] = { implicit ctx: ParsingRun[_] =>
-    CharsWhileIn(" \t", 0)
+  implicit object whitespace extends Whitespace{
+    def apply(implicit ctx: P[_]): P[Unit] = {
+      CharsWhileIn(" \t", 0)
+    }
   }
   def eval(tree: (Int, Seq[(String, Int)])): Int = {
     val (base, ops) = tree

--- a/fastparse/test/src-2.12+/fastparse/IteratorTests.scala
+++ b/fastparse/test/src-2.12+/fastparse/IteratorTests.scala
@@ -59,7 +59,7 @@ object IteratorTests extends TestSuite {
 
     test("whitespaceImmediateCutDrop"){
       import NoWhitespace.{noWhitespaceImplicit => _, _}
-      implicit val whitespace: P[_] => P[Unit] = { implicit ctx: P[_] =>
+      implicit val whitespace: Whitespace = { implicit ctx: P[_] =>
         import NoWhitespace.noWhitespaceImplicit
         " ".? ~ " ".rep
       }
@@ -210,7 +210,7 @@ object IteratorTests extends TestSuite {
 
       test("whitespaceApi"){
 
-        implicit def whitespace: P[_] => P[Unit] = { implicit ctx: P[_] =>
+        implicit def whitespace: Whitespace = { implicit ctx: P[_] =>
           " ".? ~~/ " ".repX
         }
 

--- a/fastparse/test/src/fastparse/ParsingTests.scala
+++ b/fastparse/test/src/fastparse/ParsingTests.scala
@@ -103,6 +103,15 @@ object ParsingTests extends TestSuite{
       checkFail(implicit c => "Hello" ~ ("omg" | "bbq"), ("Hellookk", 0), 5)
       checkFail(implicit c => "Hello" ~ ("omg" | "bbq"), ("ellookk", 0), 0)
     }
+    test("fail"){
+      import fastparse._
+      import NoWhitespace._
+      def fail1[T: P] = Fail.!
+      val wat = "Shouldn't success"
+      val Parsed.Failure(_, _, _) = parse(wat, fail1(_))
+      def fail2[T: P]: P[Unit] = Fail.!
+      val Parsed.Failure(_, _, _) = parse(wat, fail2(_))
+    }
     test("cut"){
       test("local"){
         // Make sure that cuts only apply to enclosing

--- a/fastparse/test/src/fastparse/WhitespaceTests.scala
+++ b/fastparse/test/src/fastparse/WhitespaceTests.scala
@@ -7,7 +7,8 @@ import utest._
   */
 object WhitespaceTests extends TestSuite{
   val tests = Tests {
-    def checkCommon(p: P[Any] => P[Unit]) = {
+    def checkCommon(p0: Whitespace) = {
+      val p = p0.apply(_)
       val Parsed.Success((), 0) = parse("", p)
       val Parsed.Success((), 0) = parse("/", p)
       val Parsed.Success((), 1) = parse(" /", p)
@@ -25,20 +26,20 @@ object WhitespaceTests extends TestSuite{
     test("scala"){
       checkCommon(ScalaWhitespace.whitespace)
       // allow nested comments
-      val Parsed.Failure(_, 11, _) = parse("/** /* /**/", ScalaWhitespace.whitespace)
-      val Parsed.Success((), 8) = parse("/*/**/*/", ScalaWhitespace.whitespace)
+      val Parsed.Failure(_, 11, _) = parse("/** /* /**/", ScalaWhitespace.whitespace.apply(_))
+      val Parsed.Success((), 8) = parse("/*/**/*/", ScalaWhitespace.whitespace.apply(_))
     }
     test("java"){
       checkCommon(JavaWhitespace.whitespace)
       // no nested comments
-      val Parsed.Success((), 11) = parse("/** /* /**/", JavaWhitespace.whitespace)
-      val Parsed.Success((), 6) = parse("/*/**/*/", JavaWhitespace.whitespace)
+      val Parsed.Success((), 11) = parse("/** /* /**/", JavaWhitespace.whitespace.apply(_))
+      val Parsed.Success((), 6) = parse("/*/**/*/", JavaWhitespace.whitespace.apply(_))
     }
     test("jsonnet"){
       checkCommon(JsonnetWhitespace.whitespace)
       // no nested comments
-      val Parsed.Success((), 11) = parse("/** /* /**/", JsonnetWhitespace.whitespace)
-      val Parsed.Success((), 6) = parse("/*/**/*/", JsonnetWhitespace.whitespace)
+      val Parsed.Success((), 11) = parse("/** /* /**/", JsonnetWhitespace.whitespace.apply(_))
+      val Parsed.Success((), 6) = parse("/*/**/*/", JsonnetWhitespace.whitespace.apply(_))
     }
   }
 

--- a/pythonparse/src/pythonparse/Expressions.scala
+++ b/pythonparse/src/pythonparse/Expressions.scala
@@ -11,7 +11,9 @@ import Lexical.kw
  * Manually transcribed from https://docs.python.org/2/reference/grammar.html
  */
 object Expressions {
-  implicit def whitespace(cfg: P[_]): P[Unit] = Lexical.wscomment(cfg)
+  implicit object whitespace extends fastparse.Whitespace {
+    def apply(ctx: P[_]): P[Unit] = Lexical.wscomment(ctx)
+  }
   def tuplize(xs: Seq[Ast.expr]) = xs match{
     case Seq(x) => x
     case xs => Ast.expr.Tuple(xs, Ast.expr_context.Load)

--- a/pythonparse/src/pythonparse/Statements.scala
+++ b/pythonparse/src/pythonparse/Statements.scala
@@ -11,7 +11,9 @@ object Statements extends Statements(0)
  * Manually transcribed from https://docs.python.org/2/reference/grammar.html
  */
 class Statements(indent: Int){
-  implicit def whitespace(cfg: P[_]): P[Unit] = Lexical.wscomment(cfg)
+  implicit object whitespace extends fastparse.Whitespace {
+    def apply(ctx: P[_]): P[Unit] = Lexical.wscomment(ctx)
+  }
   def space[$: P] = P( CharIn(" \n") )
   def NEWLINE[$: P]: P0 = P( "\n" | End )
   def ENDMARKER[$: P]: P0 = P( End )


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/fastparse/issues/261, which is caused by the whitespace `P[_] => P[Unit]` implicits firing as implicit conversions rather than the implicit parameters they were originally intended to be. Since whitespace is meant to ignore failures, this caused failures caused by the `Fail.! : P[String]` to be ignored when implicitly converted to `P[Unit]`

The fix is to create a proper `Whitespace` trait to inherit from. 

Note that this is a binary incompatible change. It's stacked on top of https://github.com/com-lihaoyi/fastparse/pull/271 for convenience, but should probably land separately after. The relevant changes are in this commit https://github.com/com-lihaoyi/fastparse/pull/272/commits/d87ab6d9de062ec1e0bbf897643cefef7cd03338 if anyone wants to look.

Note that I moved the custom whitespace tests to a `scala2.12+` folder to skip them on 2.11. 2.11 does not support SAM conversion, which makes defining custom whitespaces a lot more boilerplatey. Can still be done, but no need to burden everyone with boilerplatey examples just to cater for the 2.11 folks in the test suite. Things are unlikely to break just for 2.11 anyway