### PR TITLE
Attempt to share macro .rep logic in Scala3

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -13,7 +13,7 @@ import de.tobiasroeser.mill.vcs.version.VcsVersion
 import $ivy.`com.github.lolgab::mill-mima::0.0.13`
 import com.github.lolgab.mill.mima._
 
-val scala31 = "3.1.3"
+val scala31 = "3.2.2"
 val scala213 = "2.13.10"
 val scala212 = "2.12.17"
 val scala211 = "2.11.12"

--- a/build.sc
+++ b/build.sc
@@ -237,16 +237,17 @@ object perftests extends Module{
   object bench2 extends PerfTestModule {
     def scalaVersion0 = scala213
     def moduleDeps = Seq(
-      scalaparse.jvm(scala212).test,
-      pythonparse.jvm(scala212).test,
-      cssparse.jvm(scala212).test,
-      fastparse.jvm(scala212).test,
+      scalaparse.jvm(scala213).test,
+      pythonparse.jvm(scala213).test,
+      cssparse.jvm(scala213).test,
+      fastparse.jvm(scala213).test,
     )
 
   }
 
   object benchScala3 extends PerfTestModule {
     def scalaVersion0 = scala31
+    def sources = T.sources{ bench2.sources() }
     def moduleDeps = Seq(
       scalaparse.jvm(scala31).test,
       pythonparse.jvm(scala31).test,

--- a/fastparse/src-2/fastparse/internal/MacroImpls.scala
+++ b/fastparse/src-2/fastparse/internal/MacroImpls.scala
@@ -54,7 +54,7 @@ object MacroImpls {
           if (ctx0.verboseFailures) {
             ctx0.aggregateMsg(
               startIndex,
-              Msgs(List(new Lazy(() => name.splice.value))),
+              Msgs(new Lazy(() => name.splice.value) :: Nil),
               ctx0.failureGroupAggregate,
               startIndex < ctx0.traceIndex
             )

--- a/fastparse/src-2/fastparse/internal/RepImpls.scala
+++ b/fastparse/src-2/fastparse/internal/RepImpls.scala
@@ -2,8 +2,9 @@ package fastparse.internal
 
 
 import fastparse.{Implicits, NoWhitespace, ParsingRun}
-
+import Util.{aggregateMsgInRep, aggregateMsgPostSep}
 import scala.annotation.tailrec
+
 
 class RepImpls[T](val parse0: () => ParsingRun[T]) extends AnyVal{
   def repX[V](min: Int = 0,
@@ -262,51 +263,6 @@ class RepImpls[T](val parse0: () => ParsingRun[T]) extends AnyVal{
       }
     }
     rec(ctx.index, 0, false, ctx.cut, null, null)
-  }
-
-  private def aggregateMsgPostSep[V](startIndex: Int,
-                                     min: Int,
-                                     ctx: ParsingRun[Any],
-                                     parsedMsg: Msgs,
-                                     lastAgg: Msgs) = {
-    ctx.aggregateMsg(
-      startIndex,
-      () => parsedMsg.render + s".rep($min)",
-      // When we fail on a sep, we collect the failure aggregate of the last
-      // non-sep rep body together with the failure aggregate of the sep, since
-      // the last non-sep rep body continuing is one of the valid ways of
-      // continuing the parse
-      ctx.failureGroupAggregate ::: lastAgg
-
-    )
-  }
-
-  private def aggregateMsgInRep[V](startIndex: Int,
-                                   min: Int,
-                                   ctx: ParsingRun[Any],
-                                   sepMsg: Msgs,
-                                   parsedMsg: Msgs,
-                                   lastAgg: Msgs,
-                                   precut: Boolean) = {
-    if (sepMsg == null || precut) {
-      ctx.aggregateMsg(
-        startIndex,
-        () => parsedMsg.render + s".rep($min)",
-        if (lastAgg == null) ctx.failureGroupAggregate
-        else ctx.failureGroupAggregate ::: lastAgg
-      )
-    } else {
-      ctx.aggregateMsg(
-        startIndex,
-        () => parsedMsg.render + s".rep($min)",
-        // When we fail on a rep body, we collect both the concatenated
-        // sep and failure aggregate  of the rep body that we tried (because
-        // we backtrack past the sep on failure) as well as the failure
-        // aggregate of the previous rep, which we could have continued
-        if (lastAgg == null) Util.joinBinOp(sepMsg, parsedMsg)
-        else Util.joinBinOp(sepMsg, parsedMsg) ::: lastAgg
-      )
-    }
   }
 
 }

--- a/fastparse/src-3/fastparse/internal/MacroInlineImpls.scala
+++ b/fastparse/src-3/fastparse/internal/MacroInlineImpls.scala
@@ -109,7 +109,7 @@ object MacroInlineImpls {
     if (ctx0.verboseFailures) {
       ctx0.aggregateMsg(
         startIndex,
-        Msgs(List(new Lazy(() => name.value))),
+        Msgs(new Lazy(() => name.value) :: Nil),
         ctx0.failureGroupAggregate,
         startIndex < ctx0.traceIndex
       )

--- a/fastparse/src-3/fastparse/internal/MacroRepImpls.scala
+++ b/fastparse/src-3/fastparse/internal/MacroRepImpls.scala
@@ -50,8 +50,8 @@ object MacroRepImpls {
 
         val consumeWhitespace =
           if whitespace.asTerm.tpe =:= TypeRepr.of[fastparse.NoWhitespace.noWhitespaceImplicit.type]
-          then '{ Util.consumeWhitespace($whitespace, ctx) }
-          else '{}
+          then '{}
+          else '{ Util.consumeWhitespace($whitespace, ctx) }
 
         '{
           ctx.cut = precut | (count < actualMin && outerCut)
@@ -85,7 +85,7 @@ object MacroRepImpls {
                   ctx.cut = false
                   ${
                     sep match {
-                      case '{ null } if false =>
+                      case '{ null } =>
                         '{
                           rec(beforeSepIndex, nextCount, false, outerCut | postCut, null, parsedAgg)
                         }

--- a/fastparse/src-3/fastparse/internal/MacroRepImpls.scala
+++ b/fastparse/src-3/fastparse/internal/MacroRepImpls.scala
@@ -104,6 +104,5 @@ object MacroRepImpls {
       }
       rec(ctx1.index, 0, null)
     }
-
   }
 }

--- a/fastparse/src-3/fastparse/internal/MacroRepImpls.scala
+++ b/fastparse/src-3/fastparse/internal/MacroRepImpls.scala
@@ -82,21 +82,22 @@ object MacroRepImpls {
               repeater1.accumulate(ctx1.successValue.asInstanceOf[T], acc)
               ctx1.cut = false
               ${
-                val wsSnippet = whitespace match {
+                whitespace match {
                   case null => '{ rec(beforeSepIndex, count + 1, parsedAgg) }
                   case ws =>
-                    '{
-                      if ($ws ne _root_.fastparse.NoWhitespace.noWhitespaceImplicit) {
+                    if (ws.asTerm.tpe =:= TypeRepr.of[fastparse.NoWhitespace.noWhitespaceImplicit.type]){
+                      '{ rec(beforeSepIndex, count + 1, parsedAgg) }
+                    } else {
+                      '{
                         _root_.fastparse.internal.Util.consumeWhitespace($ws, ctx1)
-                      }
-                      if (!ctx1.isSuccess && ctx1.cut) ctx1.asInstanceOf[_root_.fastparse.ParsingRun[scala.Nothing]]
-                      else {
-                        ctx1.cut = false
-                        rec(beforeSepIndex, count + 1, parsedAgg)
+                        if (!ctx1.isSuccess && ctx1.cut) ctx1.asInstanceOf[_root_.fastparse.ParsingRun[scala.Nothing]]
+                        else {
+                          ctx1.cut = false
+                          rec(beforeSepIndex, count + 1, parsedAgg)
+                        }
                       }
                     }
                 }
-                wsSnippet
               }
             }
           }

--- a/fastparse/src-3/fastparse/internal/RepImpls.scala
+++ b/fastparse/src-3/fastparse/internal/RepImpls.scala
@@ -1,0 +1,17 @@
+//package fastparse.internal
+//
+//
+//import fastparse.{Implicits, NoWhitespace, ParsingRun}
+//import Util.{aggregateMsgInRep, aggregateMsgPostSep}
+//import scala.annotation.tailrec
+//
+//inline def rep[T, V](inline parse0: => ParsingRun[T],
+//                     min: Int = 0,
+//                     inline sep: => ParsingRun[_] = null,
+//                     max: Int = Int.MaxValue,
+//                     exactly: Int = -1)
+//                    (implicit repeater: Implicits.Repeater[T, V],
+//                     whitespace: fastparse.Whitespace,
+//                     ctx: ParsingRun[Any]): ParsingRun[V] = {
+//
+//}

--- a/fastparse/src-3/fastparse/package.scala
+++ b/fastparse/src-3/fastparse/package.scala
@@ -243,7 +243,7 @@ package object fastparse extends fastparse.SharedPackageDefs {
      * consuming zero characters.
      */
     def unary_!(implicit ctx: P[Any]): P[Unit] = SharedPackageDefs.unary_!(() => parse0)
-  end extension
+
 
   /** Provides logging-related [[LogByNameOps]] implicits on [[String]]. */
   implicit def LogOpsStr(parse0: String)(implicit ctx: P[Any]): fastparse.LogByNameOps[Unit] = LogByNameOps(parse0)

--- a/fastparse/src-3/fastparse/package.scala
+++ b/fastparse/src-3/fastparse/package.scala
@@ -173,11 +173,11 @@ package object fastparse extends fastparse.SharedPackageDefs {
       * The convenience parameter `exactly` is provided to set both `min` and
       * `max` to the same value.
       */
-    def rep[V](
+    inline def rep[V](
         min: Int = 0,
         sep: => P[_] = null,
-        max: Int = Int.MaxValue,
-        exactly: Int = -1
+        inline max: Int = Int.MaxValue,
+        inline exactly: Int = -1
     )(using
         repeater: Implicits.Repeater[T, V],
         whitespace: Whitespace,
@@ -195,16 +195,16 @@ package object fastparse extends fastparse.SharedPackageDefs {
       * The convenience parameter `exactly` is provided to set both `min` and
       * `max` to the same value.
       */
-    inline def repX[V, Max <: Int, Exact <: Int](
+    inline def repX[V](
         min: Int = 0,
         sep: => P[_] = null,
-        inline max: Max = Int.MaxValue,
-        inline exactly: Exact = -1
+        inline max: Int = Int.MaxValue,
+        inline exactly: Int = -1
     )(implicit
         repeater: Implicits.Repeater[T, V],
         ctx: P[Any]
     ): P[V] =
-      inline if max == Int.MaxValue && exactly == -1
+      if max == Int.MaxValue && exactly == -1
       then new RepImpls[T](() => parse0).repX[V](min, sep)
       else new RepImpls[T](() => parse0).repX[V](min, sep, max, exactly)
 

--- a/fastparse/src-3/fastparse/package.scala
+++ b/fastparse/src-3/fastparse/package.scala
@@ -135,7 +135,7 @@ package object fastparse extends fastparse.SharedPackageDefs {
       * index of the last run.
       */
     inline def rep[V](using repeater: Implicits.Repeater[T, V], whitespace: Whitespace, ctx: P[Any]): P[V] =
-      ${ MacroRepImpls.repXMacro0[T, V]('parse0, 'whitespace, null)('repeater, 'ctx) }
+      ${ MacroRepImpls.repMacro0[T, V]('parse0, '{null}, 'whitespace, '{-1}, '{Int.MaxValue}, '{-1})('repeater, 'ctx) }
 
     /** Raw repeat operator; runs the LHS parser 0 or more times *without*
       * any whitespace in between, and returns
@@ -143,7 +143,7 @@ package object fastparse extends fastparse.SharedPackageDefs {
       * index of the last run.
       */
     inline def repX[V](using repeater: Implicits.Repeater[T, V], ctx: P[Any]): P[V] =
-      ${ MacroRepImpls.repXMacro0[T, V]('parse0, null, null)('repeater, 'ctx) }
+      ${ MacroRepImpls.repMacro0[T, V]('parse0, '{null}, '{fastparse.NoWhitespace.noWhitespaceImplicit}, '{-1}, '{Int.MaxValue}, '{-1})('repeater, 'ctx) }
 
     /// ** Repeat operator; runs the LHS parser at least `min`
     //  * times separated by the given whitespace (in implicit scope),
@@ -174,18 +174,28 @@ package object fastparse extends fastparse.SharedPackageDefs {
       * `max` to the same value.
       */
     inline def rep[V](
-        min: Int = 0,
-        sep: => P[_] = null,
+        inline min: Int = 0,
+        inline sep: => P[_] = null,
         inline max: Int = Int.MaxValue,
         inline exactly: Int = -1
     )(using
         repeater: Implicits.Repeater[T, V],
         whitespace: Whitespace,
         ctx: P[Any]
-    ): P[V] =
-      if max == Int.MaxValue && exactly == -1
-      then new RepImpls[T](() => parse0).rep[V](min, sep)
-      else new RepImpls[T](() => parse0).rep[V](min, sep, max, exactly)
+    ): P[V] = ${
+      MacroRepImpls.repMacro0[T, V](
+        'parse0,
+        'sep,
+        'whitespace,
+        'min,
+        'max,
+        'exactly
+      )(
+        'repeater,
+        'ctx
+      )
+    }
+
 
     /** Raw repeat operator; runs the LHS parser at least `min` to at most `max`
       * times separated by the
@@ -196,17 +206,27 @@ package object fastparse extends fastparse.SharedPackageDefs {
       * `max` to the same value.
       */
     inline def repX[V](
-        min: Int = 0,
-        sep: => P[_] = null,
+        inline min: Int = 0,
+        inline sep: => P[_] = null,
         inline max: Int = Int.MaxValue,
         inline exactly: Int = -1
     )(implicit
         repeater: Implicits.Repeater[T, V],
         ctx: P[Any]
-    ): P[V] =
-      if max == Int.MaxValue && exactly == -1
-      then new RepImpls[T](() => parse0).repX[V](min, sep)
-      else new RepImpls[T](() => parse0).repX[V](min, sep, max, exactly)
+    ): P[V] = ${
+      MacroRepImpls.repMacro0[T, V](
+        'parse0,
+        'sep,
+        '{fastparse.NoWhitespace.noWhitespaceImplicit},
+        'min,
+        'max,
+        'exactly
+      )(
+        'repeater,
+        'ctx
+      )
+    }
+
 
 
     /**

--- a/fastparse/src/fastparse/ParsingRun.scala
+++ b/fastparse/src/fastparse/ParsingRun.scala
@@ -184,7 +184,7 @@ final class ParsingRun[+T](val input: ParserInput,
   def aggregateMsg(startIndex: Int,
                    msgToSet: () => String,
                    msgToAggregate: Msgs): Unit = {
-    aggregateMsg(startIndex, Msgs(List(new Lazy(msgToSet))), msgToAggregate)
+    aggregateMsg(startIndex, Msgs(new Lazy(msgToSet) :: Nil), msgToAggregate)
   }
 
   def aggregateMsg(startIndex: Int,
@@ -212,15 +212,15 @@ final class ParsingRun[+T](val input: ParserInput,
     val f2 = new Lazy(f)
     if (!isSuccess){
       if (index == traceIndex) failureTerminalAggregate ::= f2
-      if (lastFailureMsg == null) lastFailureMsg = Msgs(List(f2))
+      if (lastFailureMsg == null) lastFailureMsg = Msgs(f2 :: Nil)
     }
 
-    shortParserMsg = if (startIndex >= traceIndex) Msgs(List(f2)) else Msgs.empty
+    shortParserMsg = if (startIndex >= traceIndex) Msgs(f2 :: Nil) else Msgs.empty
     failureGroupAggregate = if (checkAggregate(startIndex)) shortParserMsg else Msgs.empty
   }
 
   def setMsg(startIndex: Int, f: () => String): Unit = {
-    setMsg(startIndex, Msgs(List(new Lazy(f))))
+    setMsg(startIndex, Msgs(new Lazy(f) :: Nil))
   }
 
   def setMsg(startIndex: Int, f: Msgs): Unit = {

--- a/fastparse/src/fastparse/internal/Util.scala
+++ b/fastparse/src/fastparse/internal/Util.scala
@@ -13,7 +13,7 @@ object Util {
   def joinBinOp(lhs: Msgs, rhs: Msgs) =
     if (lhs.value.isEmpty) rhs
     else if (rhs.value.isEmpty) lhs
-    else Msgs(List(new Lazy(() => lhs.render + " ~ " + rhs.render)))
+    else Msgs(new Lazy(() => lhs.render + " ~ " + rhs.render) :: Nil)
 
   def consumeWhitespace[V](whitespace: fastparse.Whitespace, ctx: ParsingRun[Any]) = {
     val oldCapturing = ctx.noDropBuffer // completely disallow dropBuffer

--- a/fastparse/src/fastparse/internal/Util.scala
+++ b/fastparse/src/fastparse/internal/Util.scala
@@ -98,6 +98,52 @@ object Util {
 
     sb.result()
   }
+
+
+  def aggregateMsgPostSep[V](startIndex: Int,
+                                     min: Int,
+                                     ctx: ParsingRun[Any],
+                                     parsedMsg: Msgs,
+                                     lastAgg: Msgs) = {
+    ctx.aggregateMsg(
+      startIndex,
+      () => parsedMsg.render + s".rep($min)",
+      // When we fail on a sep, we collect the failure aggregate of the last
+      // non-sep rep body together with the failure aggregate of the sep, since
+      // the last non-sep rep body continuing is one of the valid ways of
+      // continuing the parse
+      ctx.failureGroupAggregate ::: lastAgg
+
+    )
+  }
+
+  def aggregateMsgInRep[V](startIndex: Int,
+                                   min: Int,
+                                   ctx: ParsingRun[Any],
+                                   sepMsg: Msgs,
+                                   parsedMsg: Msgs,
+                                   lastAgg: Msgs,
+                                   precut: Boolean) = {
+    if (sepMsg == null || precut) {
+      ctx.aggregateMsg(
+        startIndex,
+        () => parsedMsg.render + s".rep($min)",
+        if (lastAgg == null) ctx.failureGroupAggregate
+        else ctx.failureGroupAggregate ::: lastAgg
+      )
+    } else {
+      ctx.aggregateMsg(
+        startIndex,
+        () => parsedMsg.render + s".rep($min)",
+        // When we fail on a rep body, we collect both the concatenated
+        // sep and failure aggregate  of the rep body that we tried (because
+        // we backtrack past the sep on failure) as well as the failure
+        // aggregate of the previous rep, which we could have continued
+        if (lastAgg == null) Util.joinBinOp(sepMsg, parsedMsg)
+        else Util.joinBinOp(sepMsg, parsedMsg) ::: lastAgg
+      )
+    }
+  }
 }
 
 class Lazy[T](calc0: () => T){

--- a/fastparse/test/src/fastparse/ExampleTests.scala
+++ b/fastparse/test/src/fastparse/ExampleTests.scala
@@ -68,6 +68,7 @@ object ExampleTests extends TestSuite{
 //        val Parsed.Failure(_, 1, _) = parse("aa", ab(_))
 //      }
 
+
       test("repeat"){
 //        def ab[$: P] = P( "a".rep ~ "b" )
 //        val Parsed.Success(_, 8) = parse("aaaaaaab", ab(_))

--- a/fastparse/test/src/fastparse/ExampleTests.scala
+++ b/fastparse/test/src/fastparse/ExampleTests.scala
@@ -10,548 +10,547 @@ import fastparse.internal.Logger
 object ExampleTests extends TestSuite{
   import fastparse.NoWhitespace._
   val tests = Tests{
-//    test("basic"){
-//      test("simple"){
-//        import fastparse._, NoWhitespace._
-//        def parseA[$: P] = P("a")
-//
-//        val Parsed.Success(value, successIndex) = parse("a", parseA(_))
-//        assert(value == (), successIndex == 1)
-//
-//        val f @ Parsed.Failure(label, index, extra) = parse("b", parseA(_))
-//        assert(
-//          label == "",
-//          index == 0,
-//          f.msg == """Position 1:1, found "b""""
-//        )
-//      }
-//
-//      test("failures"){
-//        import fastparse._, NoWhitespace._
-//        def parseEither[$: P] = P( "a" | "b" )
-//        def parseA[$: P] = P( parseEither.? ~ "c" )
-//        val f @ Parsed.Failure(failureString, index, extra) = parse("d", parseA(_))
-//
-//        assert(
-//          failureString == "",
-//          index == 0,
-//          f.msg == """Position 1:1, found "d""""
-//        )
-//
-//        // .trace() collects additional metadata to use for error reporting
-//        val trace = f.trace()
-//
-//
-//        // `.msg` records the last parser that failed, which is "c", and
-//        // `.longMsg` also shows the parsing stack at point of failure
-//        assert(
-//          trace.label == "\"c\"",
-//          trace.index == 0,
-//          trace.msg == """Expected "c":1:1, found "d"""",
-//          trace.longMsg == """Expected parseA:1:1 / "c":1:1, found "d""""
-//        )
-//
-//        // aggregateMsg and longAggregateMsg record all parsers
-//        // failing at the position, "a" | "b" | "c",
-//
-//        assert(
-//          trace.aggregateMsg == """Expected (parseEither | "c"):1:1, found "d"""",
-//          trace.longAggregateMsg == """Expected parseA:1:1 / (parseEither | "c"):1:1, found "d""""
-//        )
-//      }
-//
-//      test("sequence"){
-//        def ab[$: P] = P( "a" ~ "b" )
-//
-//        val Parsed.Success(_, 2) = parse("ab", ab(_))
-//
-//        val Parsed.Failure(_, 1, _) = parse("aa", ab(_))
-//      }
+    test("basic"){
+      test("simple"){
+        import fastparse._, NoWhitespace._
+        def parseA[$: P] = P("a")
+
+        val Parsed.Success(value, successIndex) = parse("a", parseA(_))
+        assert(value == (), successIndex == 1)
+
+        val f @ Parsed.Failure(label, index, extra) = parse("b", parseA(_))
+        assert(
+          label == "",
+          index == 0,
+          f.msg == """Position 1:1, found "b""""
+        )
+      }
+
+      test("failures"){
+        import fastparse._, NoWhitespace._
+        def parseEither[$: P] = P( "a" | "b" )
+        def parseA[$: P] = P( parseEither.? ~ "c" )
+        val f @ Parsed.Failure(failureString, index, extra) = parse("d", parseA(_))
+
+        assert(
+          failureString == "",
+          index == 0,
+          f.msg == """Position 1:1, found "d""""
+        )
+
+        // .trace() collects additional metadata to use for error reporting
+        val trace = f.trace()
+
+
+        // `.msg` records the last parser that failed, which is "c", and
+        // `.longMsg` also shows the parsing stack at point of failure
+        assert(
+          trace.label == "\"c\"",
+          trace.index == 0,
+          trace.msg == """Expected "c":1:1, found "d"""",
+          trace.longMsg == """Expected parseA:1:1 / "c":1:1, found "d""""
+        )
+
+        // aggregateMsg and longAggregateMsg record all parsers
+        // failing at the position, "a" | "b" | "c",
+
+        assert(
+          trace.aggregateMsg == """Expected (parseEither | "c"):1:1, found "d"""",
+          trace.longAggregateMsg == """Expected parseA:1:1 / (parseEither | "c"):1:1, found "d""""
+        )
+      }
+
+      test("sequence"){
+        def ab[$: P] = P( "a" ~ "b" )
+
+        val Parsed.Success(_, 2) = parse("ab", ab(_))
+
+        val Parsed.Failure(_, 1, _) = parse("aa", ab(_))
+      }
 
 
       test("repeat"){
-//        def ab[$: P] = P( "a".rep ~ "b" )
-//        val Parsed.Success(_, 8) = parse("aaaaaaab", ab(_))
-//        val Parsed.Success(_, 4) = parse("aaaba", ab(_))
+        def ab[$: P] = P( "a".rep ~ "b" )
+        val Parsed.Success(_, 8) = parse("aaaaaaab", ab(_))
+        val Parsed.Success(_, 4) = parse("aaaba", ab(_))
 
-//        def abc[$: P] = P( "a".rep(sep="b") ~ "c")
-//        val Parsed.Success(_, 8) = parse("abababac", abc(_))
-//        val Parsed.Failure(_, 3, _) = parse("abaabac", abc(_))
-//
+        def abc[$: P] = P( "a".rep(sep="b") ~ "c")
+        val Parsed.Success(_, 8) = parse("abababac", abc(_))
+        val Parsed.Failure(_, 3, _) = parse("abaabac", abc(_))
 
         def ab4[$: P] = P( "a".rep(min=2, max=4, sep="b", exactly = -1) )
         val Parsed.Success(_, 7) = parse("ababababababa", ab4(_))
-//
-//        def ab2exactly[$: P] = P( "ab".rep(exactly=2) )
-//        val Parsed.Success(_, 4) = parse("abab", ab2exactly(_))
-//
-//        def ab4c[$: P] = P ( "a".rep(min=2, max=4, sep="b") ~ "c" )
-//        val Parsed.Failure(_, 1, _) = parse("ac", ab4c(_))
-//        val Parsed.Success(_, 4) = parse("abac", ab4c(_))
-//        val Parsed.Success(_, 8) = parse("abababac", ab4c(_))
-//        val Parsed.Failure(_, 7, _) = parse("ababababac", ab4c(_))
+
+        def ab2exactly[$: P] = P( "ab".rep(exactly=2) )
+        val Parsed.Success(_, 4) = parse("abab", ab2exactly(_))
+
+        def ab4c[$: P] = P ( "a".rep(min=2, max=4, sep="b") ~ "c" )
+        val Parsed.Failure(_, 1, _) = parse("ac", ab4c(_))
+        val Parsed.Success(_, 4) = parse("abac", ab4c(_))
+        val Parsed.Success(_, 8) = parse("abababac", ab4c(_))
+        val Parsed.Failure(_, 7, _) = parse("ababababac", ab4c(_))
       }
 
-//      test("option"){
-//        def option[$: P] = P( "c".? ~ "a".rep(sep="b").! ~ End)
-//
-//        val Parsed.Success("aba", 3) = parse("aba", option(_))
-//        val Parsed.Success("aba", 4) = parse("caba", option(_))
-//      }
-//
-//      test("either"){
-//        def either[$: P] = P( "a".rep ~ ("b" | "c" | "d") ~ End)
-//
-//        val Parsed.Success(_, 6) = parse("aaaaab", either(_))
-//        val f @ Parsed.Failure(_, 5, _) = parse("aaaaae", either(_))
-//        val trace = f.trace().longAggregateMsg
-//        assert(
-//          f.toString == """Parsed.Failure(Position 1:6, found "e")""",
-//          trace == """Expected either:1:1 / ("a" | "b" | "c" | "d"):1:6, found "e""""
-//        )
-//      }
-//
-//      test("end"){
-//        def noEnd[$: P] = P( "a".rep ~ "b")
-//        def withEnd[$: P] = P( "a".rep ~ "b" ~ End)
-//
-//        val Parsed.Success(_, 4) = parse("aaaba", noEnd(_))
-//        val Parsed.Failure(_, 4, _) = parse("aaaba", withEnd(_))
-//      }
-//
-//      test("start"){
-//        def ab[$: P] = P( (("a" | Start) ~ "b").rep ~ End).!
-//
-//        val Parsed.Success("abab", 4) = parse("abab", ab(_))
-//        val Parsed.Success("babab", 5) = parse("babab", ab(_))
-//
-//        val Parsed.Failure(_, 2, _) = parse("abb", ab(_))
-//      }
-//
-//      test("passfail"){
-//        val Parsed.Success((), 0) = parse("asdad", Pass(_))
-//        val Parsed.Failure(_, 0, _) = parse("asdad", Fail(_))
-//      }
-//
-//      test("index"){
-//        def finder[$: P] = P( "hay".rep ~ Index ~ "needle" ~ "hay".rep )
-//
-//        val Parsed.Success(9, _) = parse("hayhayhayneedlehay", finder(_))
-//      }
-//
-//      test("capturing"){
-//        def capture1[$: P] = P( "a".rep.! ~ "b" ~ End)
-//
-//        val Parsed.Success("aaa", 4) = parse("aaab", capture1(_))
-//
-//        def capture2[$: P] = P( "a".rep.! ~ "b".! ~ End)
-//
-//        val Parsed.Success(("aaa", "b"), 4) = parse("aaab", capture2(_))
-//
-//        def capture3[$: P] = P( "a".rep.! ~ "b".! ~ "c".! ~ End)
-//
-//        val Parsed.Success(("aaa", "b", "c"), 5) = parse("aaabc", capture3(_))
-//
-//        def captureRep[$: P] = P( "a".!.rep ~ "b" ~ End)
-//
-//        val Parsed.Success(Seq("a", "a", "a"), 4) = parse("aaab", captureRep(_))
-//
-//        def captureOpt[$: P] = P( "a".rep ~ "b".!.? ~ End)
-//
-//        val Parsed.Success(Some("b"), 4) = parse("aaab", captureOpt(_))
-//      }
-//
-//      test("anychar"){
-//        def ab[$: P] = P( "'" ~ AnyChar.! ~ "'" )
-//
-//        val Parsed.Success("-", 3) = parse("'-'", ab(_))
-//
-//        val Parsed.Failure(stack, 2, _) = parse("'-='", ab(_))
-//      }
-//
-//
-//      test("lookahead"){
-//        def keyword[$: P] = P( ("hello" ~ &(" ")).!.rep )
-//
-//        val Parsed.Success(Seq("hello"), _) = parse("hello ", keyword(_))
-//        val Parsed.Success(Seq(), _) = parse("hello", keyword(_))
-//        val Parsed.Success(Seq(), _) = parse("helloX", keyword(_))
-//      }
-//
-//      test("neglookahead"){
-//        def keyword[$: P] = P( "hello" ~ !" " ~ AnyChar ~ "world" ).!
-//
-//        val Parsed.Success("hello-world", _) = parse("hello-world", keyword(_))
-//        val Parsed.Success("hello_world", _) = parse("hello_world", keyword(_))
-//
-//        val Parsed.Failure(_, 5, _) = parse("hello world", keyword(_))
-////        assert(parser == !(" "))
-//      }
-//
-//      test("map"){
-//        def binary[$: P] = P( ("0" | "1" ).rep.! )
-//        def binaryNum[$: P] = P( binary.map(Integer.parseInt(_, 2)) )
-//
-//        val Parsed.Success("1100", _) = parse("1100", binary(_))
-//        val Parsed.Success(12, _) = parse("1100", binaryNum(_))
-//      }
-//
-//      test("collect"){
-//        def binary[$: P] = P( ("0" | "1" ).rep.! )
-//        def binaryNum[$: P] = P( binary.collect { case v if v.size % 2 == 0 => Integer.parseInt(v, 2)} )
-//
-//        val Parsed.Success("1100", _) = parse("1100", binary(_))
-//        val Parsed.Failure(_, _, _) = parse("11001", binaryNum(_))
-//      }
-//
-//      test("flatMap"){
-//        def leftTag[$: P] = P( "<" ~ (!">" ~ AnyChar).rep(1).! ~ ">")
-//        def rightTag[$: P](s: String) = P( "</" ~ s.! ~ ">" )
-//        def xml[$: P] = P( leftTag.flatMap(rightTag(_)) )
-//
-//        val Parsed.Success("a", _) = parse("<a></a>", xml(_))
-//        val Parsed.Success("abcde", _) = parse("<abcde></abcde>", xml(_))
-//
-//        val failure = parse("<abcde></edcba>", xml(_)).asInstanceOf[Parsed.Failure]
-//        assert(
-//          failure.trace().longAggregateMsg == """Expected xml:1:1 / rightTag:1:8 / "abcde":1:10, found "edcba>""""
-//        )
-//      }
-//      test("flatMapFor"){
-//        def leftTag[$: P] = P( "<" ~ (!">" ~ AnyChar).rep(1).! ~ ">" )
-//        def rightTag[$: P](s: String) = P( "</" ~ s.! ~ ">" )
-//        def xml[$: P] = P(
-//          for{
-//            s <- leftTag
-//            right <- rightTag(s)
-//          } yield right
-//        )
-//
-//        val Parsed.Success("a", _) = parse("<a></a>", xml(_))
-//        val Parsed.Success("abcde", _) = parse("<abcde></abcde>", xml(_))
-//
-//        val failure = parse("<abcde></edcba>", xml(_)).asInstanceOf[Parsed.Failure]
-//        assert(
-//          failure.trace().longAggregateMsg == """Expected xml:1:1 / rightTag:1:8 / "abcde":1:10, found "edcba>""""
-//        )
-//      }
-//      test("filter"){
-//        def digits[$: P] = P(CharPred(c => '0' <= c && c <= '9').rep(1).!).map(_.toInt)
-//        def even[$: P] = P( digits.filter(_ % 2 == 0) )
-//        val Parsed.Success(12, _) = parse("12", even(_))
-//        val failure = parse("123", even(_)).asInstanceOf[Parsed.Failure]
-//      }
-//      test("opaque"){
-//        def digit[$: P] = CharIn("0-9")
-//        def letter[$: P] = CharIn("A-Z")
-//        def twice[T, $: P](p: => P[T]) = p ~ p
-//        def errorMessage[T](p: P[_] => P[T], str: String) =
-//          parse(str, p).asInstanceOf[Parsed.Failure].trace().longAggregateMsg
-//
-//        // Portuguese number plate format since 2006
-//        def numberPlate[$: P] = P(twice(digit) ~ "-" ~ twice(letter) ~ "-" ~ twice(digit))
-//
-//        val err1 = errorMessage(numberPlate(_), "11-A1-22")
-//        assert(err1 == """Expected numberPlate:1:1 / [A-Z]:1:5, found "1-22"""")
-//
-//        // Suppress implementation details from the error message
-//        def opaqueNumberPlate[$: P] = numberPlate.opaque("<number-plate>")
-//
-//        val err2 = errorMessage(opaqueNumberPlate(_), "11-A1-22")
-//        assert(err2 == """Expected <number-plate>:1:1, found "11-A1-22"""")
-//      }
-//    }
-//
-//    test("charX"){
-//      test("charPred"){
-//        def cp[$: P] = P( CharPred(_.isUpper).rep.! ~ "." ~ End )
-//
-//        val Parsed.Success("ABC", _) = parse("ABC.", cp(_))
-//        val Parsed.Failure(_, 2, _) = parse("ABc.", cp(_))
-//      }
-//
-//      test("charIn"){
-//        def ci[$: P] = P( CharIn("abc", "xyz").rep.! ~ End )
-//
-//        val Parsed.Success("aaabbccxyz", _) = parse("aaabbccxyz", ci(_))
-//        val Parsed.Failure(_, 7, _) = parse("aaabbccdxyz.", ci(_))
-//
-//
-//        def digits[$: P] = P( CharIn("0-9").rep.! )
-//
-//        val Parsed.Success("12345", _) = parse("12345abcde", digits(_))
-//        val Parsed.Success("123", _) = parse("123abcde45", digits(_))
-//      }
-//
-//      test("charsWhile"){
-//        def cw[$: P] = P( CharsWhile(_ != ' ').! )
-//
-//        val Parsed.Success("12345", _) = parse("12345", cw(_))
-//        val Parsed.Success("123", _) = parse("123 45", cw(_))
-//      }
-//      test("charsWhileIn"){
-//        def cw[$: P] = P( CharsWhileIn("123456789").! )
-//
-//        val Parsed.Success("12345", _) = parse("12345", cw(_))
-//        val Parsed.Success("123", _) = parse("123 45", cw(_))
-//      }
-//
-//      test("stringIn"){
-//        def si[$: P] = P( StringIn("cow", "cattle").!.rep(1) )
-//
-//        val Parsed.Success(Seq("cow", "cattle"), _) = parse("cowcattle", si(_))
-//        val Parsed.Success(Seq("cow"), _) = parse("cowmoo", si(_))
-//        val Parsed.Failure(_, _, _) = parse("co", si(_))
-//      }
-//    }
-//
-//    test("cuts"){
-//      test("nocut"){
-//        def alpha[$: P] = P( CharIn("a-z") )
-//        def nocut[$: P] = P( "val " ~ alpha.rep(1).! | "def " ~ alpha.rep(1).!)
-//
-//        val Parsed.Success("abcd", _) = parse("val abcd", nocut(_))
-//
-//        val failure = parse("val 1234", nocut(_)).asInstanceOf[Parsed.Failure]
-//        val trace = failure.trace().longAggregateMsg
-//        assert(
-//          failure.index == 0,
-//          trace == """Expected nocut:1:1 / ("val " ~ alpha.rep(1) | "def "):1:1, found "val 1234""""
-//        )
-//      }
-//
-//      test("withcut"){
-//        def alpha[$: P] = P( CharIn("a-z") )
-//        def nocut[$: P] = P( "val " ~/ alpha.rep(1).! | "def " ~/ alpha.rep(1).!)
-//
-//        val Parsed.Success("abcd", _) = parse("val abcd", nocut(_))
-//
-//        val failure = parse("val 1234", nocut(_)).asInstanceOf[Parsed.Failure]
-//        val trace = failure.trace().longAggregateMsg
-//        assert(
-//          failure.index == 4,
-//          trace == """Expected nocut:1:1 / alpha:1:5 / [a-z]:1:5, found "1234""""
-//        )
-//      }
-//
-//      test("repnocut"){
-//        def alpha[$: P] = P( CharIn("a-z") )
-//        def stmt[$: P] = P( "val " ~ alpha.rep(1).! ~ ";" ~ " ".rep )
-//        def stmts[$: P] = P( stmt.rep(1) ~ End )
-//
-//        val Parsed.Success(Seq("abcd"), _) = parse("val abcd;", stmts(_))
-//        val Parsed.Success(Seq("abcd", "efg"), _) = parse("val abcd; val efg;", stmts(_))
-//
-//        val failure = parse("val abcd; val ", stmts(_)).asInstanceOf[Parsed.Failure]
-//        val trace = failure.trace().longAggregateMsg
-//        assert(
-//          failure.index == 10,
-//          trace == """Expected stmts:1:1 / (" " | stmt | end-of-input):1:11, found "val """"
-//        )
-//      }
-//
-//      test("repcut"){
-//        def alpha[$: P] = P( CharIn("a-z") )
-//        def stmt[$: P] = P( "val " ~/ alpha.rep(1).! ~ ";" ~ " ".rep )
-//        def stmts[$: P] = P( stmt.rep(1) ~ End )
-//
-//        val Parsed.Success(Seq("abcd"), _) = parse("val abcd;", stmts(_))
-//        val Parsed.Success(Seq("abcd", "efg"), _) = parse("val abcd; val efg;", stmts(_))
-//
-//        val failure = parse("val abcd; val ", stmts(_)).asInstanceOf[Parsed.Failure]
-//        val trace = failure.trace().longAggregateMsg
-//        assert(
-//          failure.index == 14,
-//          trace == """Expected stmts:1:1 / stmt:1:11 / alpha:1:15 / [a-z]:1:15, found """""
-//        )
-//      }
-//
-//      test("delimiternocut"){
-//        def digits[$: P] = P( CharIn("0-9").rep(1) )
-//        def tuple[$: P] = P( "(" ~ digits.!.rep(sep=",") ~ ")" )
-//
-//        val Parsed.Success(Seq("1", "23"), _) = parse("(1,23)", tuple(_))
-//
-//        val failure = parse("(1,)", tuple(_)).asInstanceOf[Parsed.Failure]
-//        val trace = failure.trace().longAggregateMsg
-//        assert(
-//          failure.index == 2,
-//          trace == """Expected tuple:1:1 / ([0-9] | "," ~ digits | ")"):1:3, found ",)""""
-//        )
-//      }
-//
-//      test("delimitercut"){
-//        def digits[$: P] = P( CharIn("0-9").rep(1) )
-//        def tuple[$: P] = P( "(" ~ digits.!.rep(sep=","./) ~ ")" )
-//
-//        val Parsed.Success(Seq("1", "23"), _) = parse("(1,23)", tuple(_))
-//
-//        val failure = parse("(1,)", tuple(_)).asInstanceOf[Parsed.Failure]
-//        val index = failure.index
-//        val trace = failure.trace().longAggregateMsg
-//        assert(
-//          index == 3,
-//          trace == """Expected tuple:1:1 / digits:1:4 / [0-9]:1:4, found ")""""
-//        )
-//      }
-//
-//      test("endcut"){
-//        def digits[$: P] = P( CharIn("0-9").rep(1) )
-//        def tuple[$: P] = P( "(" ~ digits.!.rep(sep=","./) ~ ")" )
-//
-//        val Parsed.Success(Seq("1", "23"), _) = parse("(1,23)", tuple(_))
-//
-//        val failure = parse("(1,)", tuple(_)).asInstanceOf[Parsed.Failure]
-//        val trace = failure.trace().longAggregateMsg
-//        assert(
-//          failure.index == 3,
-//          trace == """Expected tuple:1:1 / digits:1:4 / [0-9]:1:4, found ")""""
-//        )
-//      }
-//
-//      test("composecut"){
-//        def digit[$: P] = P( CharIn("0-9") )
-//        def time1[$: P] = P( ("1".? ~ digit) ~ ":" ~/ digit ~ digit ~ ("am" | "pm") )
-//        def time2[$: P] = P( (("1" | "2").? ~ digit) ~ ":" ~/ digit ~ digit )
-//        val Parsed.Success((), _) = parse("12:30pm", time1(_))
-//        val Parsed.Success((), _) = parse("17:45", time2(_))
-//        def time[$: P] = P( time1 | time2 ).log
-//        val Parsed.Success((), _) = parse("12:30pm", time(_))
-//        val failure = parse("17:45", time(_)).asInstanceOf[Parsed.Failure]
-//        assert(failure.index == 5)  // Expects am or pm
-//      }
-//
-//      test("composenocut"){
-//        def digit[$: P] = P( CharIn("0-9") )
-//        def time1[$: P] = P( ("1".? ~ digit) ~ ":" ~/ digit ~ digit ~ ("am" | "pm") )
-//        def time2[$: P] = P( (("1" | "2").? ~ digit) ~ ":" ~/ digit ~ digit )
-//        val Parsed.Success((), _) = parse("12:30pm", time1(_))
-//        val Parsed.Success((), _) = parse("17:45", time2(_))
-//        def time[$: P] = P( NoCut(time1) | time2 )
-//        val Parsed.Success((), _) = parse("12:30pm", time(_))
-//        val Parsed.Success((), _) = parse("17:45", time(_))
-//      }
-//    }
-//
-//    test("debugging"){
-//      def check(a: Any, s: String) = assert(a.toString == s.trim)
-//      test("original"){
-//        object Foo{
-//
-//          def plus[$: P] = P( "+" )
-//          def num[$: P] = P( CharIn("0-9").rep(1) ).!.map(_.toInt)
-//          def side[$: P] = P( "(" ~ expr ~ ")" | num )
-//          def expr[$: P]: P[Int] = P( side ~ plus ~ side ).map{case (l, r) => l + r}
-//        }
-//
-//        check(
-//          parse("(1+(2+3x))+4", Foo.expr(_)),
-//          """Parsed.Failure(Position 1:1, found "(1+(2+3x))")"""
-//        )
-//      }
-//
-//      test("cuts"){
-//        object Foo{
-//
-//          def plus[$: P] = P( "+" )
-//          def num[$: P] = P( CharIn("0-9").rep(1) ).!.map(_.toInt)
-//          def side[$: P] = P( "(" ~/ expr ~ ")" | num )
-//          def expr[$: P]: P[Int] = P( side ~ plus ~ side ).map{case (l, r) => l + r}
-//        }
-//        check(
-//          parse("(1+(2+3x))+4", Foo.expr(_)),
-//          """Parsed.Failure(Position 1:8, found "x))+4")"""
-//        )
-//      }
-//
-//      test("logSimple"){
-//        val logged = collection.mutable.Buffer.empty[String]
-//        implicit val logger = Logger(logged.append(_))
-//
-//        def DeepFailure[$: P] = P( "C" ).log
-//        def Foo[$: P] = P( (DeepFailure | "A") ~ "B".!).log
-//
-//        parse("AB", Foo(_))
-//
-//        val allLogged = logged.mkString("\n")
-//
-//        val expected =
-//          """+Foo:1:1, cut
-//            |  +DeepFailure:1:1
-//            |  -DeepFailure:1:1:Failure(DeepFailure:1:1 / "C":1:1 ..."AB")
-//            |-Foo:1:1:Success(1:3, cut)
-//            |
-//        """.stripMargin.trim
-//        assert(allLogged == expected)
-//      }
-//
-//      test("log"){
-//        val captured = collection.mutable.Buffer.empty[String]
-//        implicit val logger = Logger(captured.append(_))
-//        object Foo{
-//
-//          def plus[$: P] = P( "+" )
-//          def num[$: P] = P( CharIn("0-9").rep(1) ).!.map(_.toInt)
-//          def side[$: P] = P( "(" ~/ expr ~ ")" | num ).log
-//          def expr[$: P]: P[Int] = P( side ~ plus ~ side ).map{case (l, r) => l + r}.log
-//        }
-//
-//
-//        parse("(1+(2+3x))+4", Foo.expr(_))
-//
-//        val expected = Predef.augmentString("""
-//          +expr:1:1, cut
-//            +side:1:1, cut
-//              +expr:1:2, cut
-//                +side:1:2, cut
-//                -side:1:2:Success(1:3, cut)
-//                +side:1:4, cut
-//                  +expr:1:5, cut
-//                    +side:1:5, cut
-//                    -side:1:5:Success(1:6, cut)
-//                    +side:1:7, cut
-//                    -side:1:7:Success(1:8, cut)
-//                  -expr:1:5:Success(1:8, cut)
-//                -side:1:4:Failure(side:1:4 / ")":1:8 ..."(2+3x))+4", cut)
-//              -expr:1:2:Failure(expr:1:2 / side:1:4 / ")":1:8 ..."1+(2+3x))+", cut)
-//            -side:1:1:Failure(side:1:1 / expr:1:2 / side:1:4 / ")":1:8 ..."(1+(2+3x))", cut)
-//          -expr:1:1:Failure(expr:1:1 / side:1:1 / expr:1:2 / side:1:4 / ")":1:8 ..."(1+(2+3x))", cut)
-//        """).lines.filter(_.trim != "").toSeq
-//        val minIndent = expected.map(_.takeWhile(_ == ' ').length).min
-//        val expectedString = expected.map(_.drop(minIndent)).mkString("\n")
-//        val capturedString = captured.mkString("\n")
-//        assert(capturedString == expectedString)
-//      }
-//    }
-//
-//    test("higherorder"){
-//      def Indexed[$: P, T](p: => P[T]): P[(Int, T, Int)] = P( Index ~ p ~ Index )
-//
-//      def Add[$: P] = P( Num ~ "+" ~ Num )
-//      def Num[$: P] = Indexed( CharsWhileIn("0-9").rep.! )
-//
-//      val Parsed.Success((0, "1", 1, (2, "2", 3)), _) = parse("1+2", Add(_))
-//    }
-//
-//    test("folding"){
-//      sealed trait AndOr
-//      case object And extends AndOr
-//      case object Or extends AndOr
-//      def and[$: P] = P(IgnoreCase("And")).map(_ => And)
-//      def or[$: P] = P(IgnoreCase("Or")).map(_ => Or)
-//      def andOr[$: P] = P(and | or)
-//
-//      def check(input: String, expectedOutput: String) = {
-//        val folded = parse(input, andOr(_)).fold(
-//          (_, _, _) => s"Cannot parse $input as an AndOr",
-//          (v, _) => s"Parsed: $v"
-//        )
-//        assert(folded == expectedOutput)
-//      }
-//
-//      check("AnD", "Parsed: And")
-//      check("oR", "Parsed: Or")
-//      check("IllegalBooleanOperation", "Cannot parse IllegalBooleanOperation as an AndOr")
-//    }
+      test("option"){
+        def option[$: P] = P( "c".? ~ "a".rep(sep="b").! ~ End)
+
+        val Parsed.Success("aba", 3) = parse("aba", option(_))
+        val Parsed.Success("aba", 4) = parse("caba", option(_))
+      }
+
+      test("either"){
+        def either[$: P] = P( "a".rep ~ ("b" | "c" | "d") ~ End)
+
+        val Parsed.Success(_, 6) = parse("aaaaab", either(_))
+        val f @ Parsed.Failure(_, 5, _) = parse("aaaaae", either(_))
+        val trace = f.trace().longAggregateMsg
+        assert(
+          f.toString == """Parsed.Failure(Position 1:6, found "e")""",
+          trace == """Expected either:1:1 / ("a" | "b" | "c" | "d"):1:6, found "e""""
+        )
+      }
+
+      test("end"){
+        def noEnd[$: P] = P( "a".rep ~ "b")
+        def withEnd[$: P] = P( "a".rep ~ "b" ~ End)
+
+        val Parsed.Success(_, 4) = parse("aaaba", noEnd(_))
+        val Parsed.Failure(_, 4, _) = parse("aaaba", withEnd(_))
+      }
+
+      test("start"){
+        def ab[$: P] = P( (("a" | Start) ~ "b").rep ~ End).!
+
+        val Parsed.Success("abab", 4) = parse("abab", ab(_))
+        val Parsed.Success("babab", 5) = parse("babab", ab(_))
+
+        val Parsed.Failure(_, 2, _) = parse("abb", ab(_))
+      }
+
+      test("passfail"){
+        val Parsed.Success((), 0) = parse("asdad", Pass(_))
+        val Parsed.Failure(_, 0, _) = parse("asdad", Fail(_))
+      }
+
+      test("index"){
+        def finder[$: P] = P( "hay".rep ~ Index ~ "needle" ~ "hay".rep )
+
+        val Parsed.Success(9, _) = parse("hayhayhayneedlehay", finder(_))
+      }
+
+      test("capturing"){
+        def capture1[$: P] = P( "a".rep.! ~ "b" ~ End)
+
+        val Parsed.Success("aaa", 4) = parse("aaab", capture1(_))
+
+        def capture2[$: P] = P( "a".rep.! ~ "b".! ~ End)
+
+        val Parsed.Success(("aaa", "b"), 4) = parse("aaab", capture2(_))
+
+        def capture3[$: P] = P( "a".rep.! ~ "b".! ~ "c".! ~ End)
+
+        val Parsed.Success(("aaa", "b", "c"), 5) = parse("aaabc", capture3(_))
+
+        def captureRep[$: P] = P( "a".!.rep ~ "b" ~ End)
+
+        val Parsed.Success(Seq("a", "a", "a"), 4) = parse("aaab", captureRep(_))
+
+        def captureOpt[$: P] = P( "a".rep ~ "b".!.? ~ End)
+
+        val Parsed.Success(Some("b"), 4) = parse("aaab", captureOpt(_))
+      }
+
+      test("anychar"){
+        def ab[$: P] = P( "'" ~ AnyChar.! ~ "'" )
+
+        val Parsed.Success("-", 3) = parse("'-'", ab(_))
+
+        val Parsed.Failure(stack, 2, _) = parse("'-='", ab(_))
+      }
+
+
+      test("lookahead"){
+        def keyword[$: P] = P( ("hello" ~ &(" ")).!.rep )
+
+        val Parsed.Success(Seq("hello"), _) = parse("hello ", keyword(_))
+        val Parsed.Success(Seq(), _) = parse("hello", keyword(_))
+        val Parsed.Success(Seq(), _) = parse("helloX", keyword(_))
+      }
+
+      test("neglookahead"){
+        def keyword[$: P] = P( "hello" ~ !" " ~ AnyChar ~ "world" ).!
+
+        val Parsed.Success("hello-world", _) = parse("hello-world", keyword(_))
+        val Parsed.Success("hello_world", _) = parse("hello_world", keyword(_))
+
+        val Parsed.Failure(_, 5, _) = parse("hello world", keyword(_))
+//        assert(parser == !(" "))
+      }
+
+      test("map"){
+        def binary[$: P] = P( ("0" | "1" ).rep.! )
+        def binaryNum[$: P] = P( binary.map(Integer.parseInt(_, 2)) )
+
+        val Parsed.Success("1100", _) = parse("1100", binary(_))
+        val Parsed.Success(12, _) = parse("1100", binaryNum(_))
+      }
+
+      test("collect"){
+        def binary[$: P] = P( ("0" | "1" ).rep.! )
+        def binaryNum[$: P] = P( binary.collect { case v if v.size % 2 == 0 => Integer.parseInt(v, 2)} )
+
+        val Parsed.Success("1100", _) = parse("1100", binary(_))
+        val Parsed.Failure(_, _, _) = parse("11001", binaryNum(_))
+      }
+
+      test("flatMap"){
+        def leftTag[$: P] = P( "<" ~ (!">" ~ AnyChar).rep(1).! ~ ">")
+        def rightTag[$: P](s: String) = P( "</" ~ s.! ~ ">" )
+        def xml[$: P] = P( leftTag.flatMap(rightTag(_)) )
+
+        val Parsed.Success("a", _) = parse("<a></a>", xml(_))
+        val Parsed.Success("abcde", _) = parse("<abcde></abcde>", xml(_))
+
+        val failure = parse("<abcde></edcba>", xml(_)).asInstanceOf[Parsed.Failure]
+        assert(
+          failure.trace().longAggregateMsg == """Expected xml:1:1 / rightTag:1:8 / "abcde":1:10, found "edcba>""""
+        )
+      }
+      test("flatMapFor"){
+        def leftTag[$: P] = P( "<" ~ (!">" ~ AnyChar).rep(1).! ~ ">" )
+        def rightTag[$: P](s: String) = P( "</" ~ s.! ~ ">" )
+        def xml[$: P] = P(
+          for{
+            s <- leftTag
+            right <- rightTag(s)
+          } yield right
+        )
+
+        val Parsed.Success("a", _) = parse("<a></a>", xml(_))
+        val Parsed.Success("abcde", _) = parse("<abcde></abcde>", xml(_))
+
+        val failure = parse("<abcde></edcba>", xml(_)).asInstanceOf[Parsed.Failure]
+        assert(
+          failure.trace().longAggregateMsg == """Expected xml:1:1 / rightTag:1:8 / "abcde":1:10, found "edcba>""""
+        )
+      }
+      test("filter"){
+        def digits[$: P] = P(CharPred(c => '0' <= c && c <= '9').rep(1).!).map(_.toInt)
+        def even[$: P] = P( digits.filter(_ % 2 == 0) )
+        val Parsed.Success(12, _) = parse("12", even(_))
+        val failure = parse("123", even(_)).asInstanceOf[Parsed.Failure]
+      }
+      test("opaque"){
+        def digit[$: P] = CharIn("0-9")
+        def letter[$: P] = CharIn("A-Z")
+        def twice[T, $: P](p: => P[T]) = p ~ p
+        def errorMessage[T](p: P[_] => P[T], str: String) =
+          parse(str, p).asInstanceOf[Parsed.Failure].trace().longAggregateMsg
+
+        // Portuguese number plate format since 2006
+        def numberPlate[$: P] = P(twice(digit) ~ "-" ~ twice(letter) ~ "-" ~ twice(digit))
+
+        val err1 = errorMessage(numberPlate(_), "11-A1-22")
+        assert(err1 == """Expected numberPlate:1:1 / [A-Z]:1:5, found "1-22"""")
+
+        // Suppress implementation details from the error message
+        def opaqueNumberPlate[$: P] = numberPlate.opaque("<number-plate>")
+
+        val err2 = errorMessage(opaqueNumberPlate(_), "11-A1-22")
+        assert(err2 == """Expected <number-plate>:1:1, found "11-A1-22"""")
+      }
+    }
+
+    test("charX"){
+      test("charPred"){
+        def cp[$: P] = P( CharPred(_.isUpper).rep.! ~ "." ~ End )
+
+        val Parsed.Success("ABC", _) = parse("ABC.", cp(_))
+        val Parsed.Failure(_, 2, _) = parse("ABc.", cp(_))
+      }
+
+      test("charIn"){
+        def ci[$: P] = P( CharIn("abc", "xyz").rep.! ~ End )
+
+        val Parsed.Success("aaabbccxyz", _) = parse("aaabbccxyz", ci(_))
+        val Parsed.Failure(_, 7, _) = parse("aaabbccdxyz.", ci(_))
+
+
+        def digits[$: P] = P( CharIn("0-9").rep.! )
+
+        val Parsed.Success("12345", _) = parse("12345abcde", digits(_))
+        val Parsed.Success("123", _) = parse("123abcde45", digits(_))
+      }
+
+      test("charsWhile"){
+        def cw[$: P] = P( CharsWhile(_ != ' ').! )
+
+        val Parsed.Success("12345", _) = parse("12345", cw(_))
+        val Parsed.Success("123", _) = parse("123 45", cw(_))
+      }
+      test("charsWhileIn"){
+        def cw[$: P] = P( CharsWhileIn("123456789").! )
+
+        val Parsed.Success("12345", _) = parse("12345", cw(_))
+        val Parsed.Success("123", _) = parse("123 45", cw(_))
+      }
+
+      test("stringIn"){
+        def si[$: P] = P( StringIn("cow", "cattle").!.rep(1) )
+
+        val Parsed.Success(Seq("cow", "cattle"), _) = parse("cowcattle", si(_))
+        val Parsed.Success(Seq("cow"), _) = parse("cowmoo", si(_))
+        val Parsed.Failure(_, _, _) = parse("co", si(_))
+      }
+    }
+
+    test("cuts"){
+      test("nocut"){
+        def alpha[$: P] = P( CharIn("a-z") )
+        def nocut[$: P] = P( "val " ~ alpha.rep(1).! | "def " ~ alpha.rep(1).!)
+
+        val Parsed.Success("abcd", _) = parse("val abcd", nocut(_))
+
+        val failure = parse("val 1234", nocut(_)).asInstanceOf[Parsed.Failure]
+        val trace = failure.trace().longAggregateMsg
+        assert(
+          failure.index == 0,
+          trace == """Expected nocut:1:1 / ("val " ~ alpha.rep(1) | "def "):1:1, found "val 1234""""
+        )
+      }
+
+      test("withcut"){
+        def alpha[$: P] = P( CharIn("a-z") )
+        def nocut[$: P] = P( "val " ~/ alpha.rep(1).! | "def " ~/ alpha.rep(1).!)
+
+        val Parsed.Success("abcd", _) = parse("val abcd", nocut(_))
+
+        val failure = parse("val 1234", nocut(_)).asInstanceOf[Parsed.Failure]
+        val trace = failure.trace().longAggregateMsg
+        assert(
+          failure.index == 4,
+          trace == """Expected nocut:1:1 / alpha:1:5 / [a-z]:1:5, found "1234""""
+        )
+      }
+
+      test("repnocut"){
+        def alpha[$: P] = P( CharIn("a-z") )
+        def stmt[$: P] = P( "val " ~ alpha.rep(1).! ~ ";" ~ " ".rep )
+        def stmts[$: P] = P( stmt.rep(1) ~ End )
+
+        val Parsed.Success(Seq("abcd"), _) = parse("val abcd;", stmts(_))
+        val Parsed.Success(Seq("abcd", "efg"), _) = parse("val abcd; val efg;", stmts(_))
+
+        val failure = parse("val abcd; val ", stmts(_)).asInstanceOf[Parsed.Failure]
+        val trace = failure.trace().longAggregateMsg
+        assert(
+          failure.index == 10,
+          trace == """Expected stmts:1:1 / (" " | stmt | end-of-input):1:11, found "val """"
+        )
+      }
+
+      test("repcut"){
+        def alpha[$: P] = P( CharIn("a-z") )
+        def stmt[$: P] = P( "val " ~/ alpha.rep(1).! ~ ";" ~ " ".rep )
+        def stmts[$: P] = P( stmt.rep(1) ~ End )
+
+        val Parsed.Success(Seq("abcd"), _) = parse("val abcd;", stmts(_))
+        val Parsed.Success(Seq("abcd", "efg"), _) = parse("val abcd; val efg;", stmts(_))
+
+        val failure = parse("val abcd; val ", stmts(_)).asInstanceOf[Parsed.Failure]
+        val trace = failure.trace().longAggregateMsg
+        assert(
+          failure.index == 14,
+          trace == """Expected stmts:1:1 / stmt:1:11 / alpha:1:15 / [a-z]:1:15, found """""
+        )
+      }
+
+      test("delimiternocut"){
+        def digits[$: P] = P( CharIn("0-9").rep(1) )
+        def tuple[$: P] = P( "(" ~ digits.!.rep(sep=",") ~ ")" )
+
+        val Parsed.Success(Seq("1", "23"), _) = parse("(1,23)", tuple(_))
+
+        val failure = parse("(1,)", tuple(_)).asInstanceOf[Parsed.Failure]
+        val trace = failure.trace().longAggregateMsg
+        assert(
+          failure.index == 2,
+          trace == """Expected tuple:1:1 / ([0-9] | "," ~ digits | ")"):1:3, found ",)""""
+        )
+      }
+
+      test("delimitercut"){
+        def digits[$: P] = P( CharIn("0-9").rep(1) )
+        def tuple[$: P] = P( "(" ~ digits.!.rep(sep=","./) ~ ")" )
+
+        val Parsed.Success(Seq("1", "23"), _) = parse("(1,23)", tuple(_))
+
+        val failure = parse("(1,)", tuple(_)).asInstanceOf[Parsed.Failure]
+        val index = failure.index
+        val trace = failure.trace().longAggregateMsg
+        assert(
+          index == 3,
+          trace == """Expected tuple:1:1 / digits:1:4 / [0-9]:1:4, found ")""""
+        )
+      }
+
+      test("endcut"){
+        def digits[$: P] = P( CharIn("0-9").rep(1) )
+        def tuple[$: P] = P( "(" ~ digits.!.rep(sep=","./) ~ ")" )
+
+        val Parsed.Success(Seq("1", "23"), _) = parse("(1,23)", tuple(_))
+
+        val failure = parse("(1,)", tuple(_)).asInstanceOf[Parsed.Failure]
+        val trace = failure.trace().longAggregateMsg
+        assert(
+          failure.index == 3,
+          trace == """Expected tuple:1:1 / digits:1:4 / [0-9]:1:4, found ")""""
+        )
+      }
+
+      test("composecut"){
+        def digit[$: P] = P( CharIn("0-9") )
+        def time1[$: P] = P( ("1".? ~ digit) ~ ":" ~/ digit ~ digit ~ ("am" | "pm") )
+        def time2[$: P] = P( (("1" | "2").? ~ digit) ~ ":" ~/ digit ~ digit )
+        val Parsed.Success((), _) = parse("12:30pm", time1(_))
+        val Parsed.Success((), _) = parse("17:45", time2(_))
+        def time[$: P] = P( time1 | time2 ).log
+        val Parsed.Success((), _) = parse("12:30pm", time(_))
+        val failure = parse("17:45", time(_)).asInstanceOf[Parsed.Failure]
+        assert(failure.index == 5)  // Expects am or pm
+      }
+
+      test("composenocut"){
+        def digit[$: P] = P( CharIn("0-9") )
+        def time1[$: P] = P( ("1".? ~ digit) ~ ":" ~/ digit ~ digit ~ ("am" | "pm") )
+        def time2[$: P] = P( (("1" | "2").? ~ digit) ~ ":" ~/ digit ~ digit )
+        val Parsed.Success((), _) = parse("12:30pm", time1(_))
+        val Parsed.Success((), _) = parse("17:45", time2(_))
+        def time[$: P] = P( NoCut(time1) | time2 )
+        val Parsed.Success((), _) = parse("12:30pm", time(_))
+        val Parsed.Success((), _) = parse("17:45", time(_))
+      }
+    }
+
+    test("debugging"){
+      def check(a: Any, s: String) = assert(a.toString == s.trim)
+      test("original"){
+        object Foo{
+
+          def plus[$: P] = P( "+" )
+          def num[$: P] = P( CharIn("0-9").rep(1) ).!.map(_.toInt)
+          def side[$: P] = P( "(" ~ expr ~ ")" | num )
+          def expr[$: P]: P[Int] = P( side ~ plus ~ side ).map{case (l, r) => l + r}
+        }
+
+        check(
+          parse("(1+(2+3x))+4", Foo.expr(_)),
+          """Parsed.Failure(Position 1:1, found "(1+(2+3x))")"""
+        )
+      }
+
+      test("cuts"){
+        object Foo{
+
+          def plus[$: P] = P( "+" )
+          def num[$: P] = P( CharIn("0-9").rep(1) ).!.map(_.toInt)
+          def side[$: P] = P( "(" ~/ expr ~ ")" | num )
+          def expr[$: P]: P[Int] = P( side ~ plus ~ side ).map{case (l, r) => l + r}
+        }
+        check(
+          parse("(1+(2+3x))+4", Foo.expr(_)),
+          """Parsed.Failure(Position 1:8, found "x))+4")"""
+        )
+      }
+
+      test("logSimple"){
+        val logged = collection.mutable.Buffer.empty[String]
+        implicit val logger = Logger(logged.append(_))
+
+        def DeepFailure[$: P] = P( "C" ).log
+        def Foo[$: P] = P( (DeepFailure | "A") ~ "B".!).log
+
+        parse("AB", Foo(_))
+
+        val allLogged = logged.mkString("\n")
+
+        val expected =
+          """+Foo:1:1, cut
+            |  +DeepFailure:1:1
+            |  -DeepFailure:1:1:Failure(DeepFailure:1:1 / "C":1:1 ..."AB")
+            |-Foo:1:1:Success(1:3, cut)
+            |
+        """.stripMargin.trim
+        assert(allLogged == expected)
+      }
+
+      test("log"){
+        val captured = collection.mutable.Buffer.empty[String]
+        implicit val logger = Logger(captured.append(_))
+        object Foo{
+
+          def plus[$: P] = P( "+" )
+          def num[$: P] = P( CharIn("0-9").rep(1) ).!.map(_.toInt)
+          def side[$: P] = P( "(" ~/ expr ~ ")" | num ).log
+          def expr[$: P]: P[Int] = P( side ~ plus ~ side ).map{case (l, r) => l + r}.log
+        }
+
+
+        parse("(1+(2+3x))+4", Foo.expr(_))
+
+        val expected = Predef.augmentString("""
+          +expr:1:1, cut
+            +side:1:1, cut
+              +expr:1:2, cut
+                +side:1:2, cut
+                -side:1:2:Success(1:3, cut)
+                +side:1:4, cut
+                  +expr:1:5, cut
+                    +side:1:5, cut
+                    -side:1:5:Success(1:6, cut)
+                    +side:1:7, cut
+                    -side:1:7:Success(1:8, cut)
+                  -expr:1:5:Success(1:8, cut)
+                -side:1:4:Failure(side:1:4 / ")":1:8 ..."(2+3x))+4", cut)
+              -expr:1:2:Failure(expr:1:2 / side:1:4 / ")":1:8 ..."1+(2+3x))+", cut)
+            -side:1:1:Failure(side:1:1 / expr:1:2 / side:1:4 / ")":1:8 ..."(1+(2+3x))", cut)
+          -expr:1:1:Failure(expr:1:1 / side:1:1 / expr:1:2 / side:1:4 / ")":1:8 ..."(1+(2+3x))", cut)
+        """).lines.filter(_.trim != "").toSeq
+        val minIndent = expected.map(_.takeWhile(_ == ' ').length).min
+        val expectedString = expected.map(_.drop(minIndent)).mkString("\n")
+        val capturedString = captured.mkString("\n")
+        assert(capturedString == expectedString)
+      }
+    }
+
+    test("higherorder"){
+      def Indexed[$: P, T](p: => P[T]): P[(Int, T, Int)] = P( Index ~ p ~ Index )
+
+      def Add[$: P] = P( Num ~ "+" ~ Num )
+      def Num[$: P] = Indexed( CharsWhileIn("0-9").rep.! )
+
+      val Parsed.Success((0, "1", 1, (2, "2", 3)), _) = parse("1+2", Add(_))
+    }
+
+    test("folding"){
+      sealed trait AndOr
+      case object And extends AndOr
+      case object Or extends AndOr
+      def and[$: P] = P(IgnoreCase("And")).map(_ => And)
+      def or[$: P] = P(IgnoreCase("Or")).map(_ => Or)
+      def andOr[$: P] = P(and | or)
+
+      def check(input: String, expectedOutput: String) = {
+        val folded = parse(input, andOr(_)).fold(
+          (_, _, _) => s"Cannot parse $input as an AndOr",
+          (v, _) => s"Parsed: $v"
+        )
+        assert(folded == expectedOutput)
+      }
+
+      check("AnD", "Parsed: And")
+      check("oR", "Parsed: Or")
+      check("IllegalBooleanOperation", "Cannot parse IllegalBooleanOperation as an AndOr")
+    }
   }
 }

--- a/fastparse/test/src/fastparse/ExampleTests.scala
+++ b/fastparse/test/src/fastparse/ExampleTests.scala
@@ -10,545 +10,547 @@ import fastparse.internal.Logger
 object ExampleTests extends TestSuite{
   import fastparse.NoWhitespace._
   val tests = Tests{
-    test("basic"){
-      test("simple"){
-        import fastparse._, NoWhitespace._
-        def parseA[$: P] = P("a")
-
-        val Parsed.Success(value, successIndex) = parse("a", parseA(_))
-        assert(value == (), successIndex == 1)
-
-        val f @ Parsed.Failure(label, index, extra) = parse("b", parseA(_))
-        assert(
-          label == "",
-          index == 0,
-          f.msg == """Position 1:1, found "b""""
-        )
-      }
-
-      test("failures"){
-        import fastparse._, NoWhitespace._
-        def parseEither[$: P] = P( "a" | "b" )
-        def parseA[$: P] = P( parseEither.? ~ "c" )
-        val f @ Parsed.Failure(failureString, index, extra) = parse("d", parseA(_))
-
-        assert(
-          failureString == "",
-          index == 0,
-          f.msg == """Position 1:1, found "d""""
-        )
-
-        // .trace() collects additional metadata to use for error reporting
-        val trace = f.trace()
-
-        // `.msg` records the last parser that failed, which is "c", and
-        // `.longMsg` also shows the parsing stack at point of failure
-        assert(
-          trace.label == "\"c\"",
-          trace.index == 0,
-          trace.msg == """Expected "c":1:1, found "d"""",
-          trace.longMsg == """Expected parseA:1:1 / "c":1:1, found "d""""
-        )
-
-        // aggregateMsg and longAggregateMsg record all parsers
-        // failing at the position, "a" | "b" | "c",
-
-        assert(
-          trace.aggregateMsg == """Expected (parseEither | "c"):1:1, found "d"""",
-          trace.longAggregateMsg == """Expected parseA:1:1 / (parseEither | "c"):1:1, found "d""""
-        )
-      }
-
-      test("sequence"){
-        def ab[$: P] = P( "a" ~ "b" )
-
-        val Parsed.Success(_, 2) = parse("ab", ab(_))
-
-        val Parsed.Failure(_, 1, _) = parse("aa", ab(_))
-      }
+//    test("basic"){
+//      test("simple"){
+//        import fastparse._, NoWhitespace._
+//        def parseA[$: P] = P("a")
+//
+//        val Parsed.Success(value, successIndex) = parse("a", parseA(_))
+//        assert(value == (), successIndex == 1)
+//
+//        val f @ Parsed.Failure(label, index, extra) = parse("b", parseA(_))
+//        assert(
+//          label == "",
+//          index == 0,
+//          f.msg == """Position 1:1, found "b""""
+//        )
+//      }
+//
+//      test("failures"){
+//        import fastparse._, NoWhitespace._
+//        def parseEither[$: P] = P( "a" | "b" )
+//        def parseA[$: P] = P( parseEither.? ~ "c" )
+//        val f @ Parsed.Failure(failureString, index, extra) = parse("d", parseA(_))
+//
+//        assert(
+//          failureString == "",
+//          index == 0,
+//          f.msg == """Position 1:1, found "d""""
+//        )
+//
+//        // .trace() collects additional metadata to use for error reporting
+//        val trace = f.trace()
+//
+//
+//        // `.msg` records the last parser that failed, which is "c", and
+//        // `.longMsg` also shows the parsing stack at point of failure
+//        assert(
+//          trace.label == "\"c\"",
+//          trace.index == 0,
+//          trace.msg == """Expected "c":1:1, found "d"""",
+//          trace.longMsg == """Expected parseA:1:1 / "c":1:1, found "d""""
+//        )
+//
+//        // aggregateMsg and longAggregateMsg record all parsers
+//        // failing at the position, "a" | "b" | "c",
+//
+//        assert(
+//          trace.aggregateMsg == """Expected (parseEither | "c"):1:1, found "d"""",
+//          trace.longAggregateMsg == """Expected parseA:1:1 / (parseEither | "c"):1:1, found "d""""
+//        )
+//      }
+//
+//      test("sequence"){
+//        def ab[$: P] = P( "a" ~ "b" )
+//
+//        val Parsed.Success(_, 2) = parse("ab", ab(_))
+//
+//        val Parsed.Failure(_, 1, _) = parse("aa", ab(_))
+//      }
 
       test("repeat"){
-        def ab[$: P] = P( "a".rep ~ "b" )
-        val Parsed.Success(_, 8) = parse("aaaaaaab", ab(_))
-        val Parsed.Success(_, 4) = parse("aaaba", ab(_))
+//        def ab[$: P] = P( "a".rep ~ "b" )
+//        val Parsed.Success(_, 8) = parse("aaaaaaab", ab(_))
+//        val Parsed.Success(_, 4) = parse("aaaba", ab(_))
 
-        def abc[$: P] = P( "a".rep(sep="b") ~ "c")
-        val Parsed.Success(_, 8) = parse("abababac", abc(_))
-        val Parsed.Failure(_, 3, _) = parse("abaabac", abc(_))
+//        def abc[$: P] = P( "a".rep(sep="b") ~ "c")
+//        val Parsed.Success(_, 8) = parse("abababac", abc(_))
+//        val Parsed.Failure(_, 3, _) = parse("abaabac", abc(_))
+//
 
-        def ab4[$: P] = P( "a".rep(min=2, max=4, sep="b") )
+        def ab4[$: P] = P( "a".rep(min=2, max=4, sep="b", exactly = -1) )
         val Parsed.Success(_, 7) = parse("ababababababa", ab4(_))
-
-        def ab2exactly[$: P] = P( "ab".rep(exactly=2) )
-        val Parsed.Success(_, 4) = parse("abab", ab2exactly(_))
-
-        def ab4c[$: P] = P ( "a".rep(min=2, max=4, sep="b") ~ "c" )
-        val Parsed.Failure(_, 1, _) = parse("ac", ab4c(_))
-        val Parsed.Success(_, 4) = parse("abac", ab4c(_))
-        val Parsed.Success(_, 8) = parse("abababac", ab4c(_))
-        val Parsed.Failure(_, 7, _) = parse("ababababac", ab4c(_))
+//
+//        def ab2exactly[$: P] = P( "ab".rep(exactly=2) )
+//        val Parsed.Success(_, 4) = parse("abab", ab2exactly(_))
+//
+//        def ab4c[$: P] = P ( "a".rep(min=2, max=4, sep="b") ~ "c" )
+//        val Parsed.Failure(_, 1, _) = parse("ac", ab4c(_))
+//        val Parsed.Success(_, 4) = parse("abac", ab4c(_))
+//        val Parsed.Success(_, 8) = parse("abababac", ab4c(_))
+//        val Parsed.Failure(_, 7, _) = parse("ababababac", ab4c(_))
       }
 
-      test("option"){
-        def option[$: P] = P( "c".? ~ "a".rep(sep="b").! ~ End)
-
-        val Parsed.Success("aba", 3) = parse("aba", option(_))
-        val Parsed.Success("aba", 4) = parse("caba", option(_))
-      }
-
-      test("either"){
-        def either[$: P] = P( "a".rep ~ ("b" | "c" | "d") ~ End)
-
-        val Parsed.Success(_, 6) = parse("aaaaab", either(_))
-        val f @ Parsed.Failure(_, 5, _) = parse("aaaaae", either(_))
-        val trace = f.trace().longAggregateMsg
-        assert(
-          f.toString == """Parsed.Failure(Position 1:6, found "e")""",
-          trace == """Expected either:1:1 / ("a" | "b" | "c" | "d"):1:6, found "e""""
-        )
-      }
-
-      test("end"){
-        def noEnd[$: P] = P( "a".rep ~ "b")
-        def withEnd[$: P] = P( "a".rep ~ "b" ~ End)
-
-        val Parsed.Success(_, 4) = parse("aaaba", noEnd(_))
-        val Parsed.Failure(_, 4, _) = parse("aaaba", withEnd(_))
-      }
-
-      test("start"){
-        def ab[$: P] = P( (("a" | Start) ~ "b").rep ~ End).!
-
-        val Parsed.Success("abab", 4) = parse("abab", ab(_))
-        val Parsed.Success("babab", 5) = parse("babab", ab(_))
-
-        val Parsed.Failure(_, 2, _) = parse("abb", ab(_))
-      }
-
-      test("passfail"){
-        val Parsed.Success((), 0) = parse("asdad", Pass(_))
-        val Parsed.Failure(_, 0, _) = parse("asdad", Fail(_))
-      }
-
-      test("index"){
-        def finder[$: P] = P( "hay".rep ~ Index ~ "needle" ~ "hay".rep )
-
-        val Parsed.Success(9, _) = parse("hayhayhayneedlehay", finder(_))
-      }
-
-      test("capturing"){
-        def capture1[$: P] = P( "a".rep.! ~ "b" ~ End)
-
-        val Parsed.Success("aaa", 4) = parse("aaab", capture1(_))
-
-        def capture2[$: P] = P( "a".rep.! ~ "b".! ~ End)
-
-        val Parsed.Success(("aaa", "b"), 4) = parse("aaab", capture2(_))
-
-        def capture3[$: P] = P( "a".rep.! ~ "b".! ~ "c".! ~ End)
-
-        val Parsed.Success(("aaa", "b", "c"), 5) = parse("aaabc", capture3(_))
-
-        def captureRep[$: P] = P( "a".!.rep ~ "b" ~ End)
-
-        val Parsed.Success(Seq("a", "a", "a"), 4) = parse("aaab", captureRep(_))
-
-        def captureOpt[$: P] = P( "a".rep ~ "b".!.? ~ End)
-
-        val Parsed.Success(Some("b"), 4) = parse("aaab", captureOpt(_))
-      }
-
-      test("anychar"){
-        def ab[$: P] = P( "'" ~ AnyChar.! ~ "'" )
-
-        val Parsed.Success("-", 3) = parse("'-'", ab(_))
-
-        val Parsed.Failure(stack, 2, _) = parse("'-='", ab(_))
-      }
-
-
-      test("lookahead"){
-        def keyword[$: P] = P( ("hello" ~ &(" ")).!.rep )
-
-        val Parsed.Success(Seq("hello"), _) = parse("hello ", keyword(_))
-        val Parsed.Success(Seq(), _) = parse("hello", keyword(_))
-        val Parsed.Success(Seq(), _) = parse("helloX", keyword(_))
-      }
-
-      test("neglookahead"){
-        def keyword[$: P] = P( "hello" ~ !" " ~ AnyChar ~ "world" ).!
-
-        val Parsed.Success("hello-world", _) = parse("hello-world", keyword(_))
-        val Parsed.Success("hello_world", _) = parse("hello_world", keyword(_))
-
-        val Parsed.Failure(_, 5, _) = parse("hello world", keyword(_))
-//        assert(parser == !(" "))
-      }
-
-      test("map"){
-        def binary[$: P] = P( ("0" | "1" ).rep.! )
-        def binaryNum[$: P] = P( binary.map(Integer.parseInt(_, 2)) )
-
-        val Parsed.Success("1100", _) = parse("1100", binary(_))
-        val Parsed.Success(12, _) = parse("1100", binaryNum(_))
-      }
-
-      test("collect"){
-        def binary[$: P] = P( ("0" | "1" ).rep.! )
-        def binaryNum[$: P] = P( binary.collect { case v if v.size % 2 == 0 => Integer.parseInt(v, 2)} )
-
-        val Parsed.Success("1100", _) = parse("1100", binary(_))
-        val Parsed.Failure(_, _, _) = parse("11001", binaryNum(_))
-      }
-
-      test("flatMap"){
-        def leftTag[$: P] = P( "<" ~ (!">" ~ AnyChar).rep(1).! ~ ">")
-        def rightTag[$: P](s: String) = P( "</" ~ s.! ~ ">" )
-        def xml[$: P] = P( leftTag.flatMap(rightTag(_)) )
-
-        val Parsed.Success("a", _) = parse("<a></a>", xml(_))
-        val Parsed.Success("abcde", _) = parse("<abcde></abcde>", xml(_))
-
-        val failure = parse("<abcde></edcba>", xml(_)).asInstanceOf[Parsed.Failure]
-        assert(
-          failure.trace().longAggregateMsg == """Expected xml:1:1 / rightTag:1:8 / "abcde":1:10, found "edcba>""""
-        )
-      }
-      test("flatMapFor"){
-        def leftTag[$: P] = P( "<" ~ (!">" ~ AnyChar).rep(1).! ~ ">" )
-        def rightTag[$: P](s: String) = P( "</" ~ s.! ~ ">" )
-        def xml[$: P] = P(
-          for{
-            s <- leftTag
-            right <- rightTag(s)
-          } yield right
-        )
-
-        val Parsed.Success("a", _) = parse("<a></a>", xml(_))
-        val Parsed.Success("abcde", _) = parse("<abcde></abcde>", xml(_))
-
-        val failure = parse("<abcde></edcba>", xml(_)).asInstanceOf[Parsed.Failure]
-        assert(
-          failure.trace().longAggregateMsg == """Expected xml:1:1 / rightTag:1:8 / "abcde":1:10, found "edcba>""""
-        )
-      }
-      test("filter"){
-        def digits[$: P] = P(CharPred(c => '0' <= c && c <= '9').rep(1).!).map(_.toInt)
-        def even[$: P] = P( digits.filter(_ % 2 == 0) )
-        val Parsed.Success(12, _) = parse("12", even(_))
-        val failure = parse("123", even(_)).asInstanceOf[Parsed.Failure]
-      }
-      test("opaque"){
-        def digit[$: P] = CharIn("0-9")
-        def letter[$: P] = CharIn("A-Z")
-        def twice[T, $: P](p: => P[T]) = p ~ p
-        def errorMessage[T](p: P[_] => P[T], str: String) =
-          parse(str, p).asInstanceOf[Parsed.Failure].trace().longAggregateMsg
-
-        // Portuguese number plate format since 2006
-        def numberPlate[$: P] = P(twice(digit) ~ "-" ~ twice(letter) ~ "-" ~ twice(digit))
-
-        val err1 = errorMessage(numberPlate(_), "11-A1-22")
-        assert(err1 == """Expected numberPlate:1:1 / [A-Z]:1:5, found "1-22"""")
-
-        // Suppress implementation details from the error message
-        def opaqueNumberPlate[$: P] = numberPlate.opaque("<number-plate>")
-
-        val err2 = errorMessage(opaqueNumberPlate(_), "11-A1-22")
-        assert(err2 == """Expected <number-plate>:1:1, found "11-A1-22"""")
-      }
-    }
-
-    test("charX"){
-      test("charPred"){
-        def cp[$: P] = P( CharPred(_.isUpper).rep.! ~ "." ~ End )
-
-        val Parsed.Success("ABC", _) = parse("ABC.", cp(_))
-        val Parsed.Failure(_, 2, _) = parse("ABc.", cp(_))
-      }
-
-      test("charIn"){
-        def ci[$: P] = P( CharIn("abc", "xyz").rep.! ~ End )
-
-        val Parsed.Success("aaabbccxyz", _) = parse("aaabbccxyz", ci(_))
-        val Parsed.Failure(_, 7, _) = parse("aaabbccdxyz.", ci(_))
-
-
-        def digits[$: P] = P( CharIn("0-9").rep.! )
-
-        val Parsed.Success("12345", _) = parse("12345abcde", digits(_))
-        val Parsed.Success("123", _) = parse("123abcde45", digits(_))
-      }
-
-      test("charsWhile"){
-        def cw[$: P] = P( CharsWhile(_ != ' ').! )
-
-        val Parsed.Success("12345", _) = parse("12345", cw(_))
-        val Parsed.Success("123", _) = parse("123 45", cw(_))
-      }
-      test("charsWhileIn"){
-        def cw[$: P] = P( CharsWhileIn("123456789").! )
-
-        val Parsed.Success("12345", _) = parse("12345", cw(_))
-        val Parsed.Success("123", _) = parse("123 45", cw(_))
-      }
-
-      test("stringIn"){
-        def si[$: P] = P( StringIn("cow", "cattle").!.rep(1) )
-
-        val Parsed.Success(Seq("cow", "cattle"), _) = parse("cowcattle", si(_))
-        val Parsed.Success(Seq("cow"), _) = parse("cowmoo", si(_))
-        val Parsed.Failure(_, _, _) = parse("co", si(_))
-      }
-    }
-
-    test("cuts"){
-      test("nocut"){
-        def alpha[$: P] = P( CharIn("a-z") )
-        def nocut[$: P] = P( "val " ~ alpha.rep(1).! | "def " ~ alpha.rep(1).!)
-
-        val Parsed.Success("abcd", _) = parse("val abcd", nocut(_))
-
-        val failure = parse("val 1234", nocut(_)).asInstanceOf[Parsed.Failure]
-        val trace = failure.trace().longAggregateMsg
-        assert(
-          failure.index == 0,
-          trace == """Expected nocut:1:1 / ("val " ~ alpha.rep(1) | "def "):1:1, found "val 1234""""
-        )
-      }
-
-      test("withcut"){
-        def alpha[$: P] = P( CharIn("a-z") )
-        def nocut[$: P] = P( "val " ~/ alpha.rep(1).! | "def " ~/ alpha.rep(1).!)
-
-        val Parsed.Success("abcd", _) = parse("val abcd", nocut(_))
-
-        val failure = parse("val 1234", nocut(_)).asInstanceOf[Parsed.Failure]
-        val trace = failure.trace().longAggregateMsg
-        assert(
-          failure.index == 4,
-          trace == """Expected nocut:1:1 / alpha:1:5 / [a-z]:1:5, found "1234""""
-        )
-      }
-
-      test("repnocut"){
-        def alpha[$: P] = P( CharIn("a-z") )
-        def stmt[$: P] = P( "val " ~ alpha.rep(1).! ~ ";" ~ " ".rep )
-        def stmts[$: P] = P( stmt.rep(1) ~ End )
-
-        val Parsed.Success(Seq("abcd"), _) = parse("val abcd;", stmts(_))
-        val Parsed.Success(Seq("abcd", "efg"), _) = parse("val abcd; val efg;", stmts(_))
-
-        val failure = parse("val abcd; val ", stmts(_)).asInstanceOf[Parsed.Failure]
-        val trace = failure.trace().longAggregateMsg
-        assert(
-          failure.index == 10,
-          trace == """Expected stmts:1:1 / (" " | stmt | end-of-input):1:11, found "val """"
-        )
-      }
-
-      test("repcut"){
-        def alpha[$: P] = P( CharIn("a-z") )
-        def stmt[$: P] = P( "val " ~/ alpha.rep(1).! ~ ";" ~ " ".rep )
-        def stmts[$: P] = P( stmt.rep(1) ~ End )
-
-        val Parsed.Success(Seq("abcd"), _) = parse("val abcd;", stmts(_))
-        val Parsed.Success(Seq("abcd", "efg"), _) = parse("val abcd; val efg;", stmts(_))
-
-        val failure = parse("val abcd; val ", stmts(_)).asInstanceOf[Parsed.Failure]
-        val trace = failure.trace().longAggregateMsg
-        assert(
-          failure.index == 14,
-          trace == """Expected stmts:1:1 / stmt:1:11 / alpha:1:15 / [a-z]:1:15, found """""
-        )
-      }
-
-      test("delimiternocut"){
-        def digits[$: P] = P( CharIn("0-9").rep(1) )
-        def tuple[$: P] = P( "(" ~ digits.!.rep(sep=",") ~ ")" )
-
-        val Parsed.Success(Seq("1", "23"), _) = parse("(1,23)", tuple(_))
-
-        val failure = parse("(1,)", tuple(_)).asInstanceOf[Parsed.Failure]
-        val trace = failure.trace().longAggregateMsg
-        assert(
-          failure.index == 2,
-          trace == """Expected tuple:1:1 / ([0-9] | "," ~ digits | ")"):1:3, found ",)""""
-        )
-      }
-
-      test("delimitercut"){
-        def digits[$: P] = P( CharIn("0-9").rep(1) )
-        def tuple[$: P] = P( "(" ~ digits.!.rep(sep=","./) ~ ")" )
-
-        val Parsed.Success(Seq("1", "23"), _) = parse("(1,23)", tuple(_))
-
-        val failure = parse("(1,)", tuple(_)).asInstanceOf[Parsed.Failure]
-        val index = failure.index
-        val trace = failure.trace().longAggregateMsg
-        assert(
-          index == 3,
-          trace == """Expected tuple:1:1 / digits:1:4 / [0-9]:1:4, found ")""""
-        )
-      }
-
-      test("endcut"){
-        def digits[$: P] = P( CharIn("0-9").rep(1) )
-        def tuple[$: P] = P( "(" ~ digits.!.rep(sep=","./) ~ ")" )
-
-        val Parsed.Success(Seq("1", "23"), _) = parse("(1,23)", tuple(_))
-
-        val failure = parse("(1,)", tuple(_)).asInstanceOf[Parsed.Failure]
-        val trace = failure.trace().longAggregateMsg
-        assert(
-          failure.index == 3,
-          trace == """Expected tuple:1:1 / digits:1:4 / [0-9]:1:4, found ")""""
-        )
-      }
-
-      test("composecut"){
-        def digit[$: P] = P( CharIn("0-9") )
-        def time1[$: P] = P( ("1".? ~ digit) ~ ":" ~/ digit ~ digit ~ ("am" | "pm") )
-        def time2[$: P] = P( (("1" | "2").? ~ digit) ~ ":" ~/ digit ~ digit )
-        val Parsed.Success((), _) = parse("12:30pm", time1(_))
-        val Parsed.Success((), _) = parse("17:45", time2(_))
-        def time[$: P] = P( time1 | time2 ).log
-        val Parsed.Success((), _) = parse("12:30pm", time(_))
-        val failure = parse("17:45", time(_)).asInstanceOf[Parsed.Failure]
-        assert(failure.index == 5)  // Expects am or pm
-      }
-
-      test("composenocut"){
-        def digit[$: P] = P( CharIn("0-9") )
-        def time1[$: P] = P( ("1".? ~ digit) ~ ":" ~/ digit ~ digit ~ ("am" | "pm") )
-        def time2[$: P] = P( (("1" | "2").? ~ digit) ~ ":" ~/ digit ~ digit )
-        val Parsed.Success((), _) = parse("12:30pm", time1(_))
-        val Parsed.Success((), _) = parse("17:45", time2(_))
-        def time[$: P] = P( NoCut(time1) | time2 )
-        val Parsed.Success((), _) = parse("12:30pm", time(_))
-        val Parsed.Success((), _) = parse("17:45", time(_))
-      }
-    }
-
-    test("debugging"){
-      def check(a: Any, s: String) = assert(a.toString == s.trim)
-      test("original"){
-        object Foo{
-
-          def plus[$: P] = P( "+" )
-          def num[$: P] = P( CharIn("0-9").rep(1) ).!.map(_.toInt)
-          def side[$: P] = P( "(" ~ expr ~ ")" | num )
-          def expr[$: P]: P[Int] = P( side ~ plus ~ side ).map{case (l, r) => l + r}
-        }
-
-        check(
-          parse("(1+(2+3x))+4", Foo.expr(_)),
-          """Parsed.Failure(Position 1:1, found "(1+(2+3x))")"""
-        )
-      }
-
-      test("cuts"){
-        object Foo{
-
-          def plus[$: P] = P( "+" )
-          def num[$: P] = P( CharIn("0-9").rep(1) ).!.map(_.toInt)
-          def side[$: P] = P( "(" ~/ expr ~ ")" | num )
-          def expr[$: P]: P[Int] = P( side ~ plus ~ side ).map{case (l, r) => l + r}
-        }
-        check(
-          parse("(1+(2+3x))+4", Foo.expr(_)),
-          """Parsed.Failure(Position 1:8, found "x))+4")"""
-        )
-      }
-
-      test("logSimple"){
-        val logged = collection.mutable.Buffer.empty[String]
-        implicit val logger = Logger(logged.append(_))
-
-        def DeepFailure[$: P] = P( "C" ).log
-        def Foo[$: P] = P( (DeepFailure | "A") ~ "B".!).log
-
-        parse("AB", Foo(_))
-
-        val allLogged = logged.mkString("\n")
-
-        val expected =
-          """+Foo:1:1, cut
-            |  +DeepFailure:1:1
-            |  -DeepFailure:1:1:Failure(DeepFailure:1:1 / "C":1:1 ..."AB")
-            |-Foo:1:1:Success(1:3, cut)
-            |
-        """.stripMargin.trim
-        assert(allLogged == expected)
-      }
-
-      test("log"){
-        val captured = collection.mutable.Buffer.empty[String]
-        implicit val logger = Logger(captured.append(_))
-        object Foo{
-
-          def plus[$: P] = P( "+" )
-          def num[$: P] = P( CharIn("0-9").rep(1) ).!.map(_.toInt)
-          def side[$: P] = P( "(" ~/ expr ~ ")" | num ).log
-          def expr[$: P]: P[Int] = P( side ~ plus ~ side ).map{case (l, r) => l + r}.log
-        }
-
-
-        parse("(1+(2+3x))+4", Foo.expr(_))
-
-        val expected = Predef.augmentString("""
-          +expr:1:1, cut
-            +side:1:1, cut
-              +expr:1:2, cut
-                +side:1:2, cut
-                -side:1:2:Success(1:3, cut)
-                +side:1:4, cut
-                  +expr:1:5, cut
-                    +side:1:5, cut
-                    -side:1:5:Success(1:6, cut)
-                    +side:1:7, cut
-                    -side:1:7:Success(1:8, cut)
-                  -expr:1:5:Success(1:8, cut)
-                -side:1:4:Failure(side:1:4 / ")":1:8 ..."(2+3x))+4", cut)
-              -expr:1:2:Failure(expr:1:2 / side:1:4 / ")":1:8 ..."1+(2+3x))+", cut)
-            -side:1:1:Failure(side:1:1 / expr:1:2 / side:1:4 / ")":1:8 ..."(1+(2+3x))", cut)
-          -expr:1:1:Failure(expr:1:1 / side:1:1 / expr:1:2 / side:1:4 / ")":1:8 ..."(1+(2+3x))", cut)
-        """).lines.filter(_.trim != "").toSeq
-        val minIndent = expected.map(_.takeWhile(_ == ' ').length).min
-        val expectedString = expected.map(_.drop(minIndent)).mkString("\n")
-        val capturedString = captured.mkString("\n")
-        assert(capturedString == expectedString)
-      }
-    }
-
-    test("higherorder"){
-      def Indexed[$: P, T](p: => P[T]): P[(Int, T, Int)] = P( Index ~ p ~ Index )
-
-      def Add[$: P] = P( Num ~ "+" ~ Num )
-      def Num[$: P] = Indexed( CharsWhileIn("0-9").rep.! )
-
-      val Parsed.Success((0, "1", 1, (2, "2", 3)), _) = parse("1+2", Add(_))
-    }
-
-    test("folding"){
-      sealed trait AndOr
-      case object And extends AndOr
-      case object Or extends AndOr
-      def and[$: P] = P(IgnoreCase("And")).map(_ => And)
-      def or[$: P] = P(IgnoreCase("Or")).map(_ => Or)
-      def andOr[$: P] = P(and | or)
-
-      def check(input: String, expectedOutput: String) = {
-        val folded = parse(input, andOr(_)).fold(
-          (_, _, _) => s"Cannot parse $input as an AndOr",
-          (v, _) => s"Parsed: $v"
-        )
-        assert(folded == expectedOutput)
-      }
-
-      check("AnD", "Parsed: And")
-      check("oR", "Parsed: Or")
-      check("IllegalBooleanOperation", "Cannot parse IllegalBooleanOperation as an AndOr")
-    }
+//      test("option"){
+//        def option[$: P] = P( "c".? ~ "a".rep(sep="b").! ~ End)
+//
+//        val Parsed.Success("aba", 3) = parse("aba", option(_))
+//        val Parsed.Success("aba", 4) = parse("caba", option(_))
+//      }
+//
+//      test("either"){
+//        def either[$: P] = P( "a".rep ~ ("b" | "c" | "d") ~ End)
+//
+//        val Parsed.Success(_, 6) = parse("aaaaab", either(_))
+//        val f @ Parsed.Failure(_, 5, _) = parse("aaaaae", either(_))
+//        val trace = f.trace().longAggregateMsg
+//        assert(
+//          f.toString == """Parsed.Failure(Position 1:6, found "e")""",
+//          trace == """Expected either:1:1 / ("a" | "b" | "c" | "d"):1:6, found "e""""
+//        )
+//      }
+//
+//      test("end"){
+//        def noEnd[$: P] = P( "a".rep ~ "b")
+//        def withEnd[$: P] = P( "a".rep ~ "b" ~ End)
+//
+//        val Parsed.Success(_, 4) = parse("aaaba", noEnd(_))
+//        val Parsed.Failure(_, 4, _) = parse("aaaba", withEnd(_))
+//      }
+//
+//      test("start"){
+//        def ab[$: P] = P( (("a" | Start) ~ "b").rep ~ End).!
+//
+//        val Parsed.Success("abab", 4) = parse("abab", ab(_))
+//        val Parsed.Success("babab", 5) = parse("babab", ab(_))
+//
+//        val Parsed.Failure(_, 2, _) = parse("abb", ab(_))
+//      }
+//
+//      test("passfail"){
+//        val Parsed.Success((), 0) = parse("asdad", Pass(_))
+//        val Parsed.Failure(_, 0, _) = parse("asdad", Fail(_))
+//      }
+//
+//      test("index"){
+//        def finder[$: P] = P( "hay".rep ~ Index ~ "needle" ~ "hay".rep )
+//
+//        val Parsed.Success(9, _) = parse("hayhayhayneedlehay", finder(_))
+//      }
+//
+//      test("capturing"){
+//        def capture1[$: P] = P( "a".rep.! ~ "b" ~ End)
+//
+//        val Parsed.Success("aaa", 4) = parse("aaab", capture1(_))
+//
+//        def capture2[$: P] = P( "a".rep.! ~ "b".! ~ End)
+//
+//        val Parsed.Success(("aaa", "b"), 4) = parse("aaab", capture2(_))
+//
+//        def capture3[$: P] = P( "a".rep.! ~ "b".! ~ "c".! ~ End)
+//
+//        val Parsed.Success(("aaa", "b", "c"), 5) = parse("aaabc", capture3(_))
+//
+//        def captureRep[$: P] = P( "a".!.rep ~ "b" ~ End)
+//
+//        val Parsed.Success(Seq("a", "a", "a"), 4) = parse("aaab", captureRep(_))
+//
+//        def captureOpt[$: P] = P( "a".rep ~ "b".!.? ~ End)
+//
+//        val Parsed.Success(Some("b"), 4) = parse("aaab", captureOpt(_))
+//      }
+//
+//      test("anychar"){
+//        def ab[$: P] = P( "'" ~ AnyChar.! ~ "'" )
+//
+//        val Parsed.Success("-", 3) = parse("'-'", ab(_))
+//
+//        val Parsed.Failure(stack, 2, _) = parse("'-='", ab(_))
+//      }
+//
+//
+//      test("lookahead"){
+//        def keyword[$: P] = P( ("hello" ~ &(" ")).!.rep )
+//
+//        val Parsed.Success(Seq("hello"), _) = parse("hello ", keyword(_))
+//        val Parsed.Success(Seq(), _) = parse("hello", keyword(_))
+//        val Parsed.Success(Seq(), _) = parse("helloX", keyword(_))
+//      }
+//
+//      test("neglookahead"){
+//        def keyword[$: P] = P( "hello" ~ !" " ~ AnyChar ~ "world" ).!
+//
+//        val Parsed.Success("hello-world", _) = parse("hello-world", keyword(_))
+//        val Parsed.Success("hello_world", _) = parse("hello_world", keyword(_))
+//
+//        val Parsed.Failure(_, 5, _) = parse("hello world", keyword(_))
+////        assert(parser == !(" "))
+//      }
+//
+//      test("map"){
+//        def binary[$: P] = P( ("0" | "1" ).rep.! )
+//        def binaryNum[$: P] = P( binary.map(Integer.parseInt(_, 2)) )
+//
+//        val Parsed.Success("1100", _) = parse("1100", binary(_))
+//        val Parsed.Success(12, _) = parse("1100", binaryNum(_))
+//      }
+//
+//      test("collect"){
+//        def binary[$: P] = P( ("0" | "1" ).rep.! )
+//        def binaryNum[$: P] = P( binary.collect { case v if v.size % 2 == 0 => Integer.parseInt(v, 2)} )
+//
+//        val Parsed.Success("1100", _) = parse("1100", binary(_))
+//        val Parsed.Failure(_, _, _) = parse("11001", binaryNum(_))
+//      }
+//
+//      test("flatMap"){
+//        def leftTag[$: P] = P( "<" ~ (!">" ~ AnyChar).rep(1).! ~ ">")
+//        def rightTag[$: P](s: String) = P( "</" ~ s.! ~ ">" )
+//        def xml[$: P] = P( leftTag.flatMap(rightTag(_)) )
+//
+//        val Parsed.Success("a", _) = parse("<a></a>", xml(_))
+//        val Parsed.Success("abcde", _) = parse("<abcde></abcde>", xml(_))
+//
+//        val failure = parse("<abcde></edcba>", xml(_)).asInstanceOf[Parsed.Failure]
+//        assert(
+//          failure.trace().longAggregateMsg == """Expected xml:1:1 / rightTag:1:8 / "abcde":1:10, found "edcba>""""
+//        )
+//      }
+//      test("flatMapFor"){
+//        def leftTag[$: P] = P( "<" ~ (!">" ~ AnyChar).rep(1).! ~ ">" )
+//        def rightTag[$: P](s: String) = P( "</" ~ s.! ~ ">" )
+//        def xml[$: P] = P(
+//          for{
+//            s <- leftTag
+//            right <- rightTag(s)
+//          } yield right
+//        )
+//
+//        val Parsed.Success("a", _) = parse("<a></a>", xml(_))
+//        val Parsed.Success("abcde", _) = parse("<abcde></abcde>", xml(_))
+//
+//        val failure = parse("<abcde></edcba>", xml(_)).asInstanceOf[Parsed.Failure]
+//        assert(
+//          failure.trace().longAggregateMsg == """Expected xml:1:1 / rightTag:1:8 / "abcde":1:10, found "edcba>""""
+//        )
+//      }
+//      test("filter"){
+//        def digits[$: P] = P(CharPred(c => '0' <= c && c <= '9').rep(1).!).map(_.toInt)
+//        def even[$: P] = P( digits.filter(_ % 2 == 0) )
+//        val Parsed.Success(12, _) = parse("12", even(_))
+//        val failure = parse("123", even(_)).asInstanceOf[Parsed.Failure]
+//      }
+//      test("opaque"){
+//        def digit[$: P] = CharIn("0-9")
+//        def letter[$: P] = CharIn("A-Z")
+//        def twice[T, $: P](p: => P[T]) = p ~ p
+//        def errorMessage[T](p: P[_] => P[T], str: String) =
+//          parse(str, p).asInstanceOf[Parsed.Failure].trace().longAggregateMsg
+//
+//        // Portuguese number plate format since 2006
+//        def numberPlate[$: P] = P(twice(digit) ~ "-" ~ twice(letter) ~ "-" ~ twice(digit))
+//
+//        val err1 = errorMessage(numberPlate(_), "11-A1-22")
+//        assert(err1 == """Expected numberPlate:1:1 / [A-Z]:1:5, found "1-22"""")
+//
+//        // Suppress implementation details from the error message
+//        def opaqueNumberPlate[$: P] = numberPlate.opaque("<number-plate>")
+//
+//        val err2 = errorMessage(opaqueNumberPlate(_), "11-A1-22")
+//        assert(err2 == """Expected <number-plate>:1:1, found "11-A1-22"""")
+//      }
+//    }
+//
+//    test("charX"){
+//      test("charPred"){
+//        def cp[$: P] = P( CharPred(_.isUpper).rep.! ~ "." ~ End )
+//
+//        val Parsed.Success("ABC", _) = parse("ABC.", cp(_))
+//        val Parsed.Failure(_, 2, _) = parse("ABc.", cp(_))
+//      }
+//
+//      test("charIn"){
+//        def ci[$: P] = P( CharIn("abc", "xyz").rep.! ~ End )
+//
+//        val Parsed.Success("aaabbccxyz", _) = parse("aaabbccxyz", ci(_))
+//        val Parsed.Failure(_, 7, _) = parse("aaabbccdxyz.", ci(_))
+//
+//
+//        def digits[$: P] = P( CharIn("0-9").rep.! )
+//
+//        val Parsed.Success("12345", _) = parse("12345abcde", digits(_))
+//        val Parsed.Success("123", _) = parse("123abcde45", digits(_))
+//      }
+//
+//      test("charsWhile"){
+//        def cw[$: P] = P( CharsWhile(_ != ' ').! )
+//
+//        val Parsed.Success("12345", _) = parse("12345", cw(_))
+//        val Parsed.Success("123", _) = parse("123 45", cw(_))
+//      }
+//      test("charsWhileIn"){
+//        def cw[$: P] = P( CharsWhileIn("123456789").! )
+//
+//        val Parsed.Success("12345", _) = parse("12345", cw(_))
+//        val Parsed.Success("123", _) = parse("123 45", cw(_))
+//      }
+//
+//      test("stringIn"){
+//        def si[$: P] = P( StringIn("cow", "cattle").!.rep(1) )
+//
+//        val Parsed.Success(Seq("cow", "cattle"), _) = parse("cowcattle", si(_))
+//        val Parsed.Success(Seq("cow"), _) = parse("cowmoo", si(_))
+//        val Parsed.Failure(_, _, _) = parse("co", si(_))
+//      }
+//    }
+//
+//    test("cuts"){
+//      test("nocut"){
+//        def alpha[$: P] = P( CharIn("a-z") )
+//        def nocut[$: P] = P( "val " ~ alpha.rep(1).! | "def " ~ alpha.rep(1).!)
+//
+//        val Parsed.Success("abcd", _) = parse("val abcd", nocut(_))
+//
+//        val failure = parse("val 1234", nocut(_)).asInstanceOf[Parsed.Failure]
+//        val trace = failure.trace().longAggregateMsg
+//        assert(
+//          failure.index == 0,
+//          trace == """Expected nocut:1:1 / ("val " ~ alpha.rep(1) | "def "):1:1, found "val 1234""""
+//        )
+//      }
+//
+//      test("withcut"){
+//        def alpha[$: P] = P( CharIn("a-z") )
+//        def nocut[$: P] = P( "val " ~/ alpha.rep(1).! | "def " ~/ alpha.rep(1).!)
+//
+//        val Parsed.Success("abcd", _) = parse("val abcd", nocut(_))
+//
+//        val failure = parse("val 1234", nocut(_)).asInstanceOf[Parsed.Failure]
+//        val trace = failure.trace().longAggregateMsg
+//        assert(
+//          failure.index == 4,
+//          trace == """Expected nocut:1:1 / alpha:1:5 / [a-z]:1:5, found "1234""""
+//        )
+//      }
+//
+//      test("repnocut"){
+//        def alpha[$: P] = P( CharIn("a-z") )
+//        def stmt[$: P] = P( "val " ~ alpha.rep(1).! ~ ";" ~ " ".rep )
+//        def stmts[$: P] = P( stmt.rep(1) ~ End )
+//
+//        val Parsed.Success(Seq("abcd"), _) = parse("val abcd;", stmts(_))
+//        val Parsed.Success(Seq("abcd", "efg"), _) = parse("val abcd; val efg;", stmts(_))
+//
+//        val failure = parse("val abcd; val ", stmts(_)).asInstanceOf[Parsed.Failure]
+//        val trace = failure.trace().longAggregateMsg
+//        assert(
+//          failure.index == 10,
+//          trace == """Expected stmts:1:1 / (" " | stmt | end-of-input):1:11, found "val """"
+//        )
+//      }
+//
+//      test("repcut"){
+//        def alpha[$: P] = P( CharIn("a-z") )
+//        def stmt[$: P] = P( "val " ~/ alpha.rep(1).! ~ ";" ~ " ".rep )
+//        def stmts[$: P] = P( stmt.rep(1) ~ End )
+//
+//        val Parsed.Success(Seq("abcd"), _) = parse("val abcd;", stmts(_))
+//        val Parsed.Success(Seq("abcd", "efg"), _) = parse("val abcd; val efg;", stmts(_))
+//
+//        val failure = parse("val abcd; val ", stmts(_)).asInstanceOf[Parsed.Failure]
+//        val trace = failure.trace().longAggregateMsg
+//        assert(
+//          failure.index == 14,
+//          trace == """Expected stmts:1:1 / stmt:1:11 / alpha:1:15 / [a-z]:1:15, found """""
+//        )
+//      }
+//
+//      test("delimiternocut"){
+//        def digits[$: P] = P( CharIn("0-9").rep(1) )
+//        def tuple[$: P] = P( "(" ~ digits.!.rep(sep=",") ~ ")" )
+//
+//        val Parsed.Success(Seq("1", "23"), _) = parse("(1,23)", tuple(_))
+//
+//        val failure = parse("(1,)", tuple(_)).asInstanceOf[Parsed.Failure]
+//        val trace = failure.trace().longAggregateMsg
+//        assert(
+//          failure.index == 2,
+//          trace == """Expected tuple:1:1 / ([0-9] | "," ~ digits | ")"):1:3, found ",)""""
+//        )
+//      }
+//
+//      test("delimitercut"){
+//        def digits[$: P] = P( CharIn("0-9").rep(1) )
+//        def tuple[$: P] = P( "(" ~ digits.!.rep(sep=","./) ~ ")" )
+//
+//        val Parsed.Success(Seq("1", "23"), _) = parse("(1,23)", tuple(_))
+//
+//        val failure = parse("(1,)", tuple(_)).asInstanceOf[Parsed.Failure]
+//        val index = failure.index
+//        val trace = failure.trace().longAggregateMsg
+//        assert(
+//          index == 3,
+//          trace == """Expected tuple:1:1 / digits:1:4 / [0-9]:1:4, found ")""""
+//        )
+//      }
+//
+//      test("endcut"){
+//        def digits[$: P] = P( CharIn("0-9").rep(1) )
+//        def tuple[$: P] = P( "(" ~ digits.!.rep(sep=","./) ~ ")" )
+//
+//        val Parsed.Success(Seq("1", "23"), _) = parse("(1,23)", tuple(_))
+//
+//        val failure = parse("(1,)", tuple(_)).asInstanceOf[Parsed.Failure]
+//        val trace = failure.trace().longAggregateMsg
+//        assert(
+//          failure.index == 3,
+//          trace == """Expected tuple:1:1 / digits:1:4 / [0-9]:1:4, found ")""""
+//        )
+//      }
+//
+//      test("composecut"){
+//        def digit[$: P] = P( CharIn("0-9") )
+//        def time1[$: P] = P( ("1".? ~ digit) ~ ":" ~/ digit ~ digit ~ ("am" | "pm") )
+//        def time2[$: P] = P( (("1" | "2").? ~ digit) ~ ":" ~/ digit ~ digit )
+//        val Parsed.Success((), _) = parse("12:30pm", time1(_))
+//        val Parsed.Success((), _) = parse("17:45", time2(_))
+//        def time[$: P] = P( time1 | time2 ).log
+//        val Parsed.Success((), _) = parse("12:30pm", time(_))
+//        val failure = parse("17:45", time(_)).asInstanceOf[Parsed.Failure]
+//        assert(failure.index == 5)  // Expects am or pm
+//      }
+//
+//      test("composenocut"){
+//        def digit[$: P] = P( CharIn("0-9") )
+//        def time1[$: P] = P( ("1".? ~ digit) ~ ":" ~/ digit ~ digit ~ ("am" | "pm") )
+//        def time2[$: P] = P( (("1" | "2").? ~ digit) ~ ":" ~/ digit ~ digit )
+//        val Parsed.Success((), _) = parse("12:30pm", time1(_))
+//        val Parsed.Success((), _) = parse("17:45", time2(_))
+//        def time[$: P] = P( NoCut(time1) | time2 )
+//        val Parsed.Success((), _) = parse("12:30pm", time(_))
+//        val Parsed.Success((), _) = parse("17:45", time(_))
+//      }
+//    }
+//
+//    test("debugging"){
+//      def check(a: Any, s: String) = assert(a.toString == s.trim)
+//      test("original"){
+//        object Foo{
+//
+//          def plus[$: P] = P( "+" )
+//          def num[$: P] = P( CharIn("0-9").rep(1) ).!.map(_.toInt)
+//          def side[$: P] = P( "(" ~ expr ~ ")" | num )
+//          def expr[$: P]: P[Int] = P( side ~ plus ~ side ).map{case (l, r) => l + r}
+//        }
+//
+//        check(
+//          parse("(1+(2+3x))+4", Foo.expr(_)),
+//          """Parsed.Failure(Position 1:1, found "(1+(2+3x))")"""
+//        )
+//      }
+//
+//      test("cuts"){
+//        object Foo{
+//
+//          def plus[$: P] = P( "+" )
+//          def num[$: P] = P( CharIn("0-9").rep(1) ).!.map(_.toInt)
+//          def side[$: P] = P( "(" ~/ expr ~ ")" | num )
+//          def expr[$: P]: P[Int] = P( side ~ plus ~ side ).map{case (l, r) => l + r}
+//        }
+//        check(
+//          parse("(1+(2+3x))+4", Foo.expr(_)),
+//          """Parsed.Failure(Position 1:8, found "x))+4")"""
+//        )
+//      }
+//
+//      test("logSimple"){
+//        val logged = collection.mutable.Buffer.empty[String]
+//        implicit val logger = Logger(logged.append(_))
+//
+//        def DeepFailure[$: P] = P( "C" ).log
+//        def Foo[$: P] = P( (DeepFailure | "A") ~ "B".!).log
+//
+//        parse("AB", Foo(_))
+//
+//        val allLogged = logged.mkString("\n")
+//
+//        val expected =
+//          """+Foo:1:1, cut
+//            |  +DeepFailure:1:1
+//            |  -DeepFailure:1:1:Failure(DeepFailure:1:1 / "C":1:1 ..."AB")
+//            |-Foo:1:1:Success(1:3, cut)
+//            |
+//        """.stripMargin.trim
+//        assert(allLogged == expected)
+//      }
+//
+//      test("log"){
+//        val captured = collection.mutable.Buffer.empty[String]
+//        implicit val logger = Logger(captured.append(_))
+//        object Foo{
+//
+//          def plus[$: P] = P( "+" )
+//          def num[$: P] = P( CharIn("0-9").rep(1) ).!.map(_.toInt)
+//          def side[$: P] = P( "(" ~/ expr ~ ")" | num ).log
+//          def expr[$: P]: P[Int] = P( side ~ plus ~ side ).map{case (l, r) => l + r}.log
+//        }
+//
+//
+//        parse("(1+(2+3x))+4", Foo.expr(_))
+//
+//        val expected = Predef.augmentString("""
+//          +expr:1:1, cut
+//            +side:1:1, cut
+//              +expr:1:2, cut
+//                +side:1:2, cut
+//                -side:1:2:Success(1:3, cut)
+//                +side:1:4, cut
+//                  +expr:1:5, cut
+//                    +side:1:5, cut
+//                    -side:1:5:Success(1:6, cut)
+//                    +side:1:7, cut
+//                    -side:1:7:Success(1:8, cut)
+//                  -expr:1:5:Success(1:8, cut)
+//                -side:1:4:Failure(side:1:4 / ")":1:8 ..."(2+3x))+4", cut)
+//              -expr:1:2:Failure(expr:1:2 / side:1:4 / ")":1:8 ..."1+(2+3x))+", cut)
+//            -side:1:1:Failure(side:1:1 / expr:1:2 / side:1:4 / ")":1:8 ..."(1+(2+3x))", cut)
+//          -expr:1:1:Failure(expr:1:1 / side:1:1 / expr:1:2 / side:1:4 / ")":1:8 ..."(1+(2+3x))", cut)
+//        """).lines.filter(_.trim != "").toSeq
+//        val minIndent = expected.map(_.takeWhile(_ == ' ').length).min
+//        val expectedString = expected.map(_.drop(minIndent)).mkString("\n")
+//        val capturedString = captured.mkString("\n")
+//        assert(capturedString == expectedString)
+//      }
+//    }
+//
+//    test("higherorder"){
+//      def Indexed[$: P, T](p: => P[T]): P[(Int, T, Int)] = P( Index ~ p ~ Index )
+//
+//      def Add[$: P] = P( Num ~ "+" ~ Num )
+//      def Num[$: P] = Indexed( CharsWhileIn("0-9").rep.! )
+//
+//      val Parsed.Success((0, "1", 1, (2, "2", 3)), _) = parse("1+2", Add(_))
+//    }
+//
+//    test("folding"){
+//      sealed trait AndOr
+//      case object And extends AndOr
+//      case object Or extends AndOr
+//      def and[$: P] = P(IgnoreCase("And")).map(_ => And)
+//      def or[$: P] = P(IgnoreCase("Or")).map(_ => Or)
+//      def andOr[$: P] = P(and | or)
+//
+//      def check(input: String, expectedOutput: String) = {
+//        val folded = parse(input, andOr(_)).fold(
+//          (_, _, _) => s"Cannot parse $input as an AndOr",
+//          (v, _) => s"Parsed: $v"
+//        )
+//        assert(folded == expectedOutput)
+//      }
+//
+//      check("AnD", "Parsed: And")
+//      check("oR", "Parsed: Or")
+//      check("IllegalBooleanOperation", "Cannot parse IllegalBooleanOperation as an AndOr")
+//    }
   }
 }

--- a/fastparse/test/src/fastparse/JsonTests.scala
+++ b/fastparse/test/src/fastparse/JsonTests.scala
@@ -30,8 +30,8 @@ object Js {
 case class NamedFunction[T, V](f: T => V, name: String) extends (T => V){
   def apply(t: T) = f(t)
   override def toString() = name
-
 }
+
 object Json{
   import fastparse._, NoWhitespace._
   def stringChars(c: Char) = c != '\"' && c != '\\'


### PR DESCRIPTION
This PR attempts to consolidate all the macros and runtime implementations into one shared code path

Still has some performance hit v.s. the status quo, so not ready to merge