### PR TITLE
Add sourceMap mapping to Scala.js

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -38,6 +38,16 @@ object fastparse extends Module{
     def platformSegment = "js"
     def millSourcePath = super.millSourcePath / os.up
     def scalaJSVersion = crossScalaJsVersion
+    private def sourceMapOptions = T.task {
+      val vcsState = VcsVersion.vcsState()
+      vcsState.lastTag.collect {
+        case tag if vcsState.commitsSinceLastTag == 0 =>
+          val baseUrl = pomSettings().url.replace("github.com", "raw.githubusercontent.com")
+          val sourcesOptionName = if(isScala3(crossScalaVersion)) "-scalajs-mapSourceURI" else "-P:scalajs:mapSourceURI"
+          s"$sourcesOptionName:${T.workspace.toIO.toURI}->$baseUrl/$tag/"
+      }
+    }
+    override def scalacOptions = super.scalacOptions() ++ sourceMapOptions()
     object test extends Tests with CommonTestModule{
       def platformSegment = "js"
     }


### PR DESCRIPTION
This makes source maps to point to Github instead of a non-existing local source file (with the path from the CI machine)