### PR TITLE
Fix handling of terminals in opaque

### DIFF
--- a/fastparse/src/fastparse/SharedPackageDefs.scala
+++ b/fastparse/src/fastparse/SharedPackageDefs.scala
@@ -229,14 +229,17 @@ object SharedPackageDefs{
 
   def opaque[T](parse0: () => P[T], msg: String)(implicit ctx: P[Any]): P[T] = {
     val oldIndex = ctx.index
-
+    val startTerminals = ctx.terminalMsgs
     val res = parse0()
 
     val res2 =
       if (res.isSuccess) ctx.freshSuccess(ctx.successValue)
       else ctx.freshFailure(oldIndex)
 
-    if (ctx.verboseFailures) ctx.reportTerminalMsg(oldIndex, () => msg)
+    if (ctx.verboseFailures) {
+      ctx.terminalMsgs = startTerminals
+      ctx.reportTerminalMsg(oldIndex, () => msg)
+    }
 
     res2.asInstanceOf[P[T]]
   }

--- a/fastparse/test/src/fastparse/ParsingTests.scala
+++ b/fastparse/test/src/fastparse/ParsingTests.scala
@@ -243,6 +243,14 @@ object ParsingTests extends TestSuite{
       checkWhitespaceFlatMap()
       checkNonWhitespaceFlatMap()
     }
+    test("opaqueTerminals"){
+      def Test[$: P] = P("A".opaque("a") ~/ "B".opaque("b") ~/ End)
+      val trace = fastparse.parse("AAB", Test(_)).asInstanceOf[Parsed.Failure].trace()
+      println(fastparse.parse("AAB", Test(_)))
+      assert(trace.longAggregateMsg == """Expected Test:1:1 / b:1:2, found "AB"""")
+      assert(trace.longMsg == """Expected Test:1:1 / b:1:2, found "AB"""")
+      assert(trace.longTerminalsMsg == """Expected Test:1:1 / b:1:2, found "AB"""")
+    }
   }
 
   def checkWhitespaceFlatMap() = {

--- a/fastparse/test/src/fastparse/ParsingTests.scala
+++ b/fastparse/test/src/fastparse/ParsingTests.scala
@@ -246,7 +246,7 @@ object ParsingTests extends TestSuite{
     test("opaqueTerminals"){
       def Test[$: P] = P("A".opaque("a") ~/ "B".opaque("b") ~/ End)
       val trace = fastparse.parse("AAB", Test(_)).asInstanceOf[Parsed.Failure].trace()
-      println(fastparse.parse("AAB", Test(_)))
+
       assert(trace.longAggregateMsg == """Expected Test:1:1 / b:1:2, found "AB"""")
       assert(trace.longMsg == """Expected Test:1:1 / b:1:2, found "AB"""")
       assert(trace.longTerminalsMsg == """Expected Test:1:1 / b:1:2, found "AB"""")

--- a/readme/Changelog.scalatex
+++ b/readme/Changelog.scalatex
@@ -1,6 +1,12 @@
 @import Main._
 @sect{Change Log}
 
+    @sect{master}
+        @ul
+            @li
+                Fix handling of terminal parser error reporting in @code{.opaque} calls
+                @lnk("#278", "https://github.com/lihaoyi/fastparse/issues/278")
+
     @sect{3.0.0}
         @ul
             @li

--- a/scalaparse/test/src/scalaparse/unit/FailureTests.scala
+++ b/scalaparse/test/src/scalaparse/unit/FailureTests.scala
@@ -9,7 +9,7 @@ object FailureTests extends TestSuite{
     test - checkNeg(
       "package package",
       aggregate = """(QualId | PkgBlock | PkgObj)""",
-      terminals = """("`" | var-id | chars-while(OpCharNotSlash, 1) | "/" | operator | plain-id | id | "case" | "object")""",
+      terminals = """(id | "case" | "object")""",
       found = "package"
     )
 
@@ -19,7 +19,7 @@ object FailureTests extends TestSuite{
         |import import
       """.stripMargin,
       aggregate = """(ThisPath | IdPath)""",
-      terminals = """("this" | "super" | "`" | var-id | chars-while(OpCharNotSlash, 1) | "/" | operator | plain-id | id)""",
+      terminals = """("this" | "super" | id)""",
       found = "import"
     )
 
@@ -34,7 +34,7 @@ object FailureTests extends TestSuite{
         |}
       """.stripMargin,
       aggregate = """(Id | Generator | Assign)""",
-      terminals = """("`" | char-pred(UpperChar) | char-pred(LowerChar) | var-id | chars-while(OpCharNotSlash, 1) | "/" | operator | plain-id | id | "<-" | "←" | "=")""",
+      terminals = """ (id | "<-" | "=")""",
       found = "} yield x"
     )
     test - checkNeg(
@@ -43,7 +43,7 @@ object FailureTests extends TestSuite{
         |}
       """.stripMargin,
       aggregate = """(NamedType | Refinement)""",
-      terminals = """(chars-while(IdCharacter, 1) | [_] | [ \t] | "/*" | "//" | "\n" | "\r\n" | "(" | "-" | "." | [0-9] | "0x" | "true" | "false" | "`" | char-pred(UpperChar) | char-pred(LowerChar) | var-id | chars-while(OpCharNotSlash, 1) | "/" | operator | plain-id | id | filter | "\"\"\"" | "\"" | "'" | "null" | "this" | "super" | "_" | "{")""",
+      terminals = """([ \t] | "/*" | "//" | "\n" | "\r\n" | "(" | "-" | "." | [0-9] | "0x" | "true" | "false" | id | filter | "\"\"\"" | "\"" | "'" | "null" | "this" | "super" | "_" | "{")""",
       found = ")"
     )
     test - checkNeg(


### PR DESCRIPTION
We need to manually backtrack any terminals that are seen in a `.opaque` parser, since it's meant to be opaque