### PR TITLE
Fix line and column number reporting for Windows newlines

### DIFF
--- a/fastparse/src/fastparse/internal/Util.scala
+++ b/fastparse/src/fastparse/internal/Util.scala
@@ -47,30 +47,55 @@ object Util {
     rec(0)
   }
   def lineNumberLookup(data: String): Array[Int] = {
-    val lineStarts = new ArrayBuffer[Int]()
+    val lineStarts = ArrayBuffer[Int](0)
     var i = 0
     var col = 1
-    var cr = false
-    var prev: Character = null
+    // Stores:
+    // - \n if we just saw a \n
+    // - \r if we just saw a \r
+    // - -1 if we just saw both a \n and \r
+    // - 0 if we just saw a normal character
+    var state: Int = 0
     while (i < data.length){
       val char = data(i)
       if (char == '\r') {
-        if (prev != '\n' && col == 1) lineStarts.append(i)
-        col = 1
-        cr = true
+        if (state == '\r' || state == -1) {
+          lineStarts.append(i)
+          state = char
+        }else if (state == '\n') {
+          col += 1
+          state = -1
+        }else{
+          col = 1
+          state = char
+        }
       }else if (char == '\n') {
-        if (prev != '\r' && col == 1) lineStarts.append(i)
-        col = 1
-        cr = false
+        if (state == '\n' || state == -1){
+          lineStarts.append(i)
+          state = char
+        } else if (state == '\r') {
+          col += 1
+          state = -1
+        }else{
+          col = 1
+          state = char
+        }
       }else{
-        if (col == 1) lineStarts.append(i)
-        col += 1
-        cr = false
+        if (state == '\r' || state == '\n' || state == -1){
+          lineStarts.append(i)
+          state = 0
+          col = 1
+        }else {
+          state = 0
+          col += 1
+        }
       }
-      prev = char
       i += 1
     }
-    if (col == 1) lineStarts.append(i)
+
+    if (state == '\r' || state == '\n' || state == -1) {
+      lineStarts.append(i)
+    }
 
     lineStarts.toArray
   }

--- a/fastparse/src/fastparse/internal/Util.scala
+++ b/fastparse/src/fastparse/internal/Util.scala
@@ -50,46 +50,22 @@ object Util {
     val lineStarts = ArrayBuffer[Int](0)
     var i = 0
     var col = 1
-    // Stores:
-    // - \n if we just saw a \n
-    // - \r if we just saw a \r
-    // - -1 if we just saw both a \n and \r
-    // - 0 if we just saw a normal character
+    // Stores the previous char we saw, or -1 if we just saw a \r\n or \n\r pair
     var state: Int = 0
     while (i < data.length){
       val char = data(i)
-      if (char == '\r') {
-        if (state == '\r' || state == -1) {
-          lineStarts.append(i)
-          state = char
-        }else if (state == '\n') {
-          col += 1
-          state = -1
-        }else{
-          col = 1
-          state = char
-        }
-      }else if (char == '\n') {
-        if (state == '\n' || state == -1){
-          lineStarts.append(i)
-          state = char
-        } else if (state == '\r') {
-          col += 1
-          state = -1
-        }else{
-          col = 1
-          state = char
-        }
+      if (char == '\r' && state == '\n' || char == '\n' && state == '\r'){
+        col += 1
+        state = -1
+      } else if (state == '\r' || state == '\n' || state == -1) {
+        lineStarts.append(i)
+        col = 1
+        state = char
       }else{
-        if (state == '\r' || state == '\n' || state == -1){
-          lineStarts.append(i)
-          state = 0
-          col = 1
-        }else {
-          state = 0
-          col += 1
-        }
+        col += 1
+        state = char
       }
+
       i += 1
     }
 

--- a/fastparse/test/src/fastparse/UtilTests.scala
+++ b/fastparse/test/src/fastparse/UtilTests.scala
@@ -42,5 +42,56 @@ object UtilTests extends TestSuite {
       )
       assert(pretties == expected)
     }
+
+    test("unix"){
+      val txt = Array(
+        "def myScalaVersion = \"2.13.2\"\n",
+        "\n",
+        "//hello\n",
+        "println(doesntExis})"
+      ).mkString
+
+      val lineStarts = fastparse.internal.Util.lineNumberLookup(txt).toList
+
+      assert(lineStarts == List(0, 30, 31, 39))
+    }
+
+    test("carriageReturnOnly") {
+      val txt = Array(
+        "def myScalaVersion = \"2.13.2\"\r",
+        "\r",
+        "//hello\r",
+        "println(doesntExis})"
+      ).mkString
+
+      val lineStarts = fastparse.internal.Util.lineNumberLookup(txt).toList
+
+      assert(lineStarts == List(0, 30, 31, 39))
+    }
+
+    test("windows"){
+      val txt = Array(
+        "def myScalaVersion = \"2.13.2\"\r\n",
+        "\r\n",
+        "//hello\r\n",
+        "println(doesntExis})"
+      ).mkString
+
+      val lineStarts = fastparse.internal.Util.lineNumberLookup(txt).toList
+
+      assert(lineStarts == List(0, 31, 33, 42))
+    }
+    test("reverseWindows"){
+      val txt = Array(
+        "def myScalaVersion = \"2.13.2\"\n\r",
+        "\n\r",
+        "//hello\n\r",
+        "println(doesntExis})"
+      ).mkString
+
+      val lineStarts = fastparse.internal.Util.lineNumberLookup(txt).toList
+
+      assert(lineStarts == List(0, 31, 33, 42))
+    }
   }
 }


### PR DESCRIPTION
Previous implementation of `lineNumberLookup` only worked for single `\n` or `\r` newlines. This PR fixes it so it also works for `\n\r` or `\r\n` newlines and adds some basic tests