### PR TITLE
Implement fix for #296

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,18 +46,18 @@ compiled to Scala.js. These all live in `demo/`.
 Common Commands
 ---------------
 
-- `mill -w fastparse.jvm[2.12.10].test` runs the main testsuite. If you're
+- `mill -w "fastparse.jvm[2.12.10].test"` runs the main testsuite. If you're
   hacking on FastParse, this is often where you want to go
 
 - You can run the other suites via `fastparse.js`, `scalaparse.jvm`, etc. if you
   wish, but I typically don't and leave that to CI unless I'm actively working
   on the sub-project
 
-- You can use `mill -w fastparse.jvm[_].test` to run it under different Scala
+- You can use `mill -w "fastparse.jvm[_].test"` to run it under different Scala
   versions, but again I usually don't bother
 
 - `mill __.test.test` is the aggregate test-all command, but is pretty slow. You
-  can use `mill __.jvm[2.12.10].test` to run all tests only under JVM/Scala-2.12,
+  can use `mill "__.jvm[2.12.10].test"` to run all tests only under JVM/Scala-2.12,
   which is much faster and catches most issues
 
 - `mill demo.fullOpt && sbt readme/run` builds the documentation site, which can

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ compiled to Scala.js. These all live in `demo/`.
 Common Commands
 ---------------
 
+Note: you should use mill 0.11 or later.
+
 - `mill -w "fastparse.jvm[2.12.10].test"` runs the main testsuite. If you're
   hacking on FastParse, this is often where you want to go
 
@@ -57,7 +59,7 @@ Common Commands
   versions, but again I usually don't bother
 
 - `mill __.test.test` is the aggregate test-all command, but is pretty slow. You
-  can use `mill "__.jvm[2.12.10].test"` to run all tests only under JVM/Scala-2.12,
+  can use `mill "__.jvm[2.12.17].test"` to run all tests only under JVM/Scala-2.12,
   which is much faster and catches most issues
 
 - `mill demo.fullOpt && sbt readme/run` builds the documentation site, which can

--- a/build.sc
+++ b/build.sc
@@ -19,7 +19,7 @@ val scala213 = "2.13.12"
 val scala212 = "2.12.18"
 val scala211 = "2.11.12"
 val scalaJS1 = "1.12.0"
-val scalaNative04 = "0.4.9"
+val scalaNative04 = "0.4.16"
 val crossVersions = Seq(scala33, scala32, scala213, scala212, scala211)
 
 object fastparse extends Module{

--- a/build.sc
+++ b/build.sc
@@ -13,13 +13,14 @@ import $ivy.`com.github.lolgab::mill-mima::0.0.23`
 import de.tobiasroeser.mill.vcs.version.VcsVersion
 import com.github.lolgab.mill.mima._
 
-val scala31 = "3.2.2"
-val scala213 = "2.13.10"
-val scala212 = "2.12.17"
+val scala33 = "3.3.1"
+val scala32 = "3.2.2"
+val scala213 = "2.13.12"
+val scala212 = "2.12.18"
 val scala211 = "2.11.12"
 val scalaJS1 = "1.12.0"
 val scalaNative04 = "0.4.9"
-val crossVersions = Seq(scala31, scala213, scala212, scala211)
+val crossVersions = Seq(scala33, scala32, scala213, scala212, scala211)
 
 object fastparse extends Module{
   object jvm extends Cross[fastparseJvmModule](crossVersions)
@@ -218,14 +219,29 @@ object perftests extends Module{
     )
   }
 
-  object benchScala3 extends PerfTestModule {
-    def scalaVersion0 = scala31
+  object benchScala33 extends PerfTestModule {
+    def scalaVersion0 = scala33
+
+    def sources = T.sources {
+      bench2.sources()
+    }
+
+    def moduleDeps = Seq(
+      scalaparse.jvm(scala33).test,
+      pythonparse.jvm(scala33).test,
+      cssparse.jvm(scala33).test,
+      fastparse.jvm(scala33).test,
+    )
+  }
+
+  object benchScala32 extends PerfTestModule {
+    def scalaVersion0 = scala32
     def sources = T.sources{ bench2.sources() }
     def moduleDeps = Seq(
-      scalaparse.jvm(scala31).test,
-      pythonparse.jvm(scala31).test,
-      cssparse.jvm(scala31).test,
-      fastparse.jvm(scala31).test,
+      scalaparse.jvm(scala32).test,
+      pythonparse.jvm(scala32).test,
+      cssparse.jvm(scala32).test,
+      fastparse.jvm(scala32).test,
     )
   }
 

--- a/build.sc
+++ b/build.sc
@@ -26,7 +26,7 @@ val scalaNativeCrossVersions = crossVersions.filterNot(v => v == scala32 || v ==
 object fastparse extends Module{
   object jvm extends Cross[fastparseJvmModule](crossVersions)
   trait fastparseJvmModule extends FastparseModule{
-    object test extends ScalaModuleTests with CommonTestModule
+    object test extends ScalaTests with CommonTestModule
   }
 
   object js extends Cross[fastparseJsModule](crossVersions)
@@ -44,7 +44,7 @@ object fastparse extends Module{
 
     override def scalacOptions = super.scalacOptions() ++ sourceMapOptions()
 
-    object test extends ScalaJSModuleTests with CommonTestModule
+    object test extends ScalaJSTests with CommonTestModule
   }
 
 
@@ -52,7 +52,7 @@ object fastparse extends Module{
   trait fastparseNativeModule extends FastparseModule with ScalaNativeModule {
     def scalaNativeVersion = scalaNative04
 
-    object test extends ScalaNativeModuleTests with CommonTestModule
+    object test extends ScalaNativeTests with CommonTestModule
   }
 }
 
@@ -122,7 +122,7 @@ object scalaparse extends Module{
   object jvm extends Cross[ScalaParseJvmModule](crossVersions)
   trait ScalaParseJvmModule extends ExampleParseJvmModule
 
-  object native extends Cross[ScalaParseNativeModule]()
+  object native extends Cross[ScalaParseNativeModule](scalaNativeCrossVersions)
   trait ScalaParseNativeModule extends ExampleParseNativeModule
 }
 
@@ -153,13 +153,13 @@ trait ExampleParseJsModule extends CommonCrossModule with ScalaJSModule{
   def moduleDeps = Seq(fastparse.js())
   def scalaJSVersion = scalaJS1
 
-  object test extends ScalaJSModuleTests with CommonTestModule
+  object test extends ScalaJSTests with CommonTestModule
 }
 
 trait ExampleParseJvmModule extends CommonCrossModule{
   def moduleDeps = Seq(fastparse.jvm())
 
-  object test extends ScalaModuleTests with CommonTestModule{
+  object test extends ScalaTests with CommonTestModule{
     def ivyDeps = super.ivyDeps() ++ Agg(
       ivy"net.sourceforge.cssparser:cssparser:0.9.18",
     ) ++ Agg.when(!isScala3(crossScalaVersion))(
@@ -172,7 +172,7 @@ trait ExampleParseNativeModule extends CommonCrossModule with ScalaNativeModule{
   def scalaNativeVersion = scalaNative04
   def moduleDeps = Seq(fastparse.native())
 
-  object test extends ScalaNativeModuleTests with CommonTestModule
+  object test extends ScalaNativeTests with CommonTestModule
 }
 
 trait CommonCrossModule extends CrossScalaModule with PublishModule with PlatformScalaModule{

--- a/build.sc
+++ b/build.sc
@@ -21,6 +21,7 @@ val scala211 = "2.11.12"
 val scalaJS1 = "1.12.0"
 val scalaNative04 = "0.4.9"
 val crossVersions = Seq(scala33, scala32, scala213, scala212, scala211)
+val scalaNativeCrossVersions = crossVersions.filterNot(v => v == scala32 || v == scala33  )
 
 object fastparse extends Module{
   object jvm extends Cross[fastparseJvmModule](crossVersions)
@@ -46,7 +47,8 @@ object fastparse extends Module{
     object test extends ScalaJSModuleTests with CommonTestModule
   }
 
-  object native extends Cross[fastparseNativeModule](crossVersions)
+
+  object native extends Cross[fastparseNativeModule](scalaNativeCrossVersions)
   trait fastparseNativeModule extends FastparseModule with ScalaNativeModule {
     def scalaNativeVersion = scalaNative04
 
@@ -120,7 +122,7 @@ object scalaparse extends Module{
   object jvm extends Cross[ScalaParseJvmModule](crossVersions)
   trait ScalaParseJvmModule extends ExampleParseJvmModule
 
-  object native extends Cross[ScalaParseNativeModule](crossVersions)
+  object native extends Cross[ScalaParseNativeModule]()
   trait ScalaParseNativeModule extends ExampleParseNativeModule
 }
 
@@ -131,7 +133,8 @@ object cssparse extends Module{
   object jvm extends Cross[CssParseJvmModule](crossVersions)
   trait CssParseJvmModule extends ExampleParseJvmModule
 
-  object native extends Cross[CssParseNativeModule](crossVersions)
+  object native extends Cross[CssParseNativeModule](scalaNativeCrossVersions)
+
   trait CssParseNativeModule extends ExampleParseNativeModule
 }
 
@@ -142,7 +145,7 @@ object pythonparse extends Module{
   object jvm extends Cross[PythonParseJvmModule](crossVersions)
   trait PythonParseJvmModule extends ExampleParseJvmModule
 
-  object native extends Cross[PythonParseNativeModule](crossVersions)
+  object native extends Cross[PythonParseNativeModule](scalaNativeCrossVersions)
   trait PythonParseNativeModule extends ExampleParseNativeModule
 }
 

--- a/build.sc
+++ b/build.sc
@@ -15,11 +15,11 @@ import com.github.lolgab.mill.mima._
 
 val scala33 = "3.3.1"
 val scala32 = "3.2.2"
-val scala213 = "2.13.12"
-val scala212 = "2.12.18"
+val scala213 = "2.13.10"
+val scala212 = "2.12.17"
 val scala211 = "2.11.12"
 val scalaJS1 = "1.12.0"
-val scalaNative04 = "0.4.16"
+val scalaNative04 = "0.4.9"
 val crossVersions = Seq(scala33, scala32, scala213, scala212, scala211)
 
 object fastparse extends Module{
@@ -221,11 +221,7 @@ object perftests extends Module{
 
   object benchScala33 extends PerfTestModule {
     def scalaVersion0 = scala33
-
-    def sources = T.sources {
-      bench2.sources()
-    }
-
+    def sources = T.sources { bench2.sources() }
     def moduleDeps = Seq(
       scalaparse.jvm(scala33).test,
       pythonparse.jvm(scala33).test,

--- a/fastparse/src/fastparse/SharedPackageDefs.scala
+++ b/fastparse/src/fastparse/SharedPackageDefs.scala
@@ -161,7 +161,7 @@ trait SharedPackageDefs {
    */
   def Fail(msg: String)(implicit ctx: P[_]): P[Nothing] = {
     val res = ctx.freshFailure()
-    if (ctx.verboseFailures) ctx.reportTerminalMsg(ctx.index, () => "fail")
+    if (ctx.verboseFailures) ctx.reportTerminalMsg(ctx.index, () => msg)
     res
   }
   /**

--- a/fastparse/test/src/fastparse/ExampleTests.scala
+++ b/fastparse/test/src/fastparse/ExampleTests.scala
@@ -133,7 +133,7 @@ object ExampleTests extends TestSuite{
 
         def failWithLabel[$: P] = P( Fail("custom fail msg") )
         val Parsed.Failure(_, 0, extra) = parse("asdad", failWithLabel(_))
-        assert(extra.trace().longMsg == """Expected failWithLabel:1:1 / fail:1:1, found "asdad"""")
+        assert(extra.trace().longMsg == """Expected failWithLabel:1:1 / custom fail msg:1:1, found "asdad"""")
       }
 
       test("index"){


### PR DESCRIPTION
Simply replace '"fail"' with 'msg' to use the provided custom error message

Additionally:
* Add 3.3.1 as a cross-build target
* Put quotes in the "Common Commands" section of the README so that the commands are directly 
  copyable for Zsh, Csh, Bash, etc. Should work on Windows too