### PR TITLE
chore: Enable lint and fix some unused warning.

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -96,6 +96,14 @@ trait FastparseModule extends CommonCrossModule with Mima{
     Seq(PathRef(file))
   }
 
+  override def scalacOptions =
+    super.scalacOptions() ++
+      Agg.when(scalaVersion() != scala3)(
+        "-Xfatal-warnings",
+        "-Xlint:unused",
+        "-Wconf:cat=feature:s,cat=deprecation:s"
+      )
+
   def mimaReportBinaryIssues() =
     if (this.isInstanceOf[ScalaNativeModule] || this.isInstanceOf[ScalaJSModule]) T.command()
     else super.mimaReportBinaryIssues()
@@ -206,7 +214,7 @@ trait CommonTestModule extends ScalaModule with TestModule.Utest{
 
   override def scalacOptions =
     super.scalacOptions() ++
-    Agg.when(scalaVersion() == scala213)(
+    Agg.when(scalaVersion() != scala3)(
       "-Xfatal-warnings",
       "-Xlint:unused",
       "-Wconf:cat=feature:s,cat=deprecation:s"

--- a/cssparse/src/cssparse/CssParser.scala
+++ b/cssparse/src/cssparse/CssParser.scala
@@ -141,6 +141,7 @@ object CssRulesParser {
         case (ident, Some((token, Ast.StringToken(string)))) => (ident, Some(token), Some(string))
         case (ident, Some((token, Ast.IdentToken(string)))) => (ident, Some(token), Some(string))
         case (ident, None) => (ident, None, None)
+        case _ => throw new IllegalArgumentException("Should not happen.")
       })
     }
   }
@@ -204,8 +205,9 @@ object CssRulesParser {
   def atRule[$: P] = P( complexAtRule | declAtRule | (simpleAtRule ~ ";") )
 
   def qualifiedRule[$: P] = P( ((selector ~ ws) | (!"{" ~ componentValue).rep) ~ "{" ~ declarationList ~ ws ~ "}" ).map{
-    case (values: Seq[Option[Ast.ComponentValue]], block) => Ast.QualifiedRule(Right(values.flatten), block)
+    case (values: Seq[Option[Ast.ComponentValue]] @unchecked, block) => Ast.QualifiedRule(Right(values.flatten), block)
     case (selector: Ast.Selector, block) => Ast.QualifiedRule(Left(selector), block)
+    case _ => throw new IllegalArgumentException("Should not happen.")
   }
 
   def ruleList[$: P]: P[Ast.RuleList] = P( (whitespaceToken | atRule | qualifiedRule).rep ).map{

--- a/cssparse/test/src/cssparse/CssTests.scala
+++ b/cssparse/test/src/cssparse/CssTests.scala
@@ -22,7 +22,7 @@ object CssTests extends TestSuite {
             |
           """.stripMargin,
           CssRulesParser.ruleList(_)
-        )
+        ) : @unchecked
 
         assert(
           value1 ==
@@ -54,7 +54,7 @@ object CssTests extends TestSuite {
             |      -ms-text-size-adjust: 100%;
             |}
             |
-          """.stripMargin, CssRulesParser.ruleList(_))
+          """.stripMargin, CssRulesParser.ruleList(_)) : @unchecked
 
         assert(
           value2 ==
@@ -81,7 +81,7 @@ object CssTests extends TestSuite {
             |          box-shadow: none !important;
             |        }
             |
-          """.stripMargin, CssRulesParser.ruleList(_))
+          """.stripMargin, CssRulesParser.ruleList(_)) : @unchecked
 
         val expected = RuleList(Seq(
           QualifiedRule(
@@ -108,7 +108,7 @@ object CssTests extends TestSuite {
             |          background-color: #31b0d5;
             |  }
             |
-          """.stripMargin, CssRulesParser.ruleList(_))
+          """.stripMargin, CssRulesParser.ruleList(_)) : @unchecked
 
         assert(
           value4 ==
@@ -128,7 +128,7 @@ object CssTests extends TestSuite {
       }
 
       test("test5"){
-        val Parsed.Success(value5, index5) = parse(
+        val Parsed.Success(value5, _) = parse(
           """
             |
             |   [hidden],
@@ -136,7 +136,7 @@ object CssTests extends TestSuite {
             |     display: none;
             |   }
             |
-          """.stripMargin, CssRulesParser.ruleList(_))
+          """.stripMargin, CssRulesParser.ruleList(_)) : @unchecked
 
         assert(value5 == RuleList(Seq(
           QualifiedRule(
@@ -148,7 +148,7 @@ object CssTests extends TestSuite {
       }
 
       test("test6"){
-        val Parsed.Success(value6, index6) = parse(
+        val Parsed.Success(value6, _) = parse(
           """
             |
             |@media (min-width: 768px) {
@@ -157,7 +157,7 @@ object CssTests extends TestSuite {
             |          }
             |        }
             |
-          """.stripMargin, CssRulesParser.ruleList(_))
+          """.stripMargin, CssRulesParser.ruleList(_)) : @unchecked
 
         assert(value6 == RuleList(Seq(
           AtRule("media", Seq(
@@ -170,7 +170,7 @@ object CssTests extends TestSuite {
       }
 
       test("test7"){
-        val Parsed.Success(value7, index7) = parse(
+        val Parsed.Success(value7, _) = parse(
           """|
              |@rule {
              |        unicode-range: U+26;                 /* single codepoint */
@@ -179,7 +179,7 @@ object CssTests extends TestSuite {
              |        unicode-range: U+4??;                /* wildcard range */
              |        unicode-range: U+0025-00FF, U+4??;
              |}
-          """.stripMargin, CssRulesParser.ruleList(_))
+          """.stripMargin, CssRulesParser.ruleList(_)) : @unchecked
         assert(value7 == RuleList(Seq(
           AtRule("rule", Seq(), Some(Left(
             DeclarationList(Seq(
@@ -202,7 +202,7 @@ object CssTests extends TestSuite {
             |  /* test comment */
             |}
             |
-          """.stripMargin, CssRulesParser.ruleList(_))
+          """.stripMargin, CssRulesParser.ruleList(_)) : @unchecked
 
         assert(
           value2 ==

--- a/fastparse/src-2.12/fastparse/internal/NoWarn.scala
+++ b/fastparse/src-2.12/fastparse/internal/NoWarn.scala
@@ -1,6 +1,6 @@
 package fastparse.internal
 
-object NoWarn{
+object NoWarn {
   @deprecated("Use scala.annotation.nowarn instead", "3.1.1")
   class nowarn(msg: String = "")
 }

--- a/fastparse/src-2/fastparse/internal/MacroImpls.scala
+++ b/fastparse/src-2/fastparse/internal/MacroImpls.scala
@@ -2,7 +2,6 @@ package fastparse.internal
 
 import fastparse.{EagerOps, Implicits, ParserInput, ParsingRun}
 
-import scala.annotation.tailrec
 import scala.reflect.macros.blackbox.Context
 
 /**

--- a/fastparse/src-2/fastparse/internal/MacroRepImpls.scala
+++ b/fastparse/src-2/fastparse/internal/MacroRepImpls.scala
@@ -1,7 +1,6 @@
 package fastparse.internal
 
 import scala.reflect.macros.blackbox.Context
-import language.experimental.macros
 
 /**
   * Implementations of the various `.rep`/`.repX` overloads. The most common
@@ -115,7 +114,6 @@ object MacroRepImpls{
   def repXMacro1[T: c.WeakTypeTag, V: c.WeakTypeTag](c: Context)
                                                     (repeater: c.Tree,
                                                      ctx: c.Tree): c.Tree = {
-    import c.universe._
     MacroRepImpls.repXMacro0[T, V](c)(None, None)(repeater, ctx)
   }
 
@@ -123,7 +121,6 @@ object MacroRepImpls{
                                                     (min: c.Tree)
                                                     (repeater: c.Tree,
                                                      ctx: c.Tree): c.Tree = {
-    import c.universe._
     MacroRepImpls.repXMacro0[T, V](c)(None, Some(min))(repeater, ctx)
   }
 
@@ -131,7 +128,6 @@ object MacroRepImpls{
                                                       (repeater: c.Tree,
                                                        whitespace: c.Tree,
                                                        ctx: c.Tree): c.Tree = {
-    import c.universe._
     MacroRepImpls.repXMacro0[T, V](c)(Some(whitespace), None)(repeater, ctx)
   }
 
@@ -140,7 +136,6 @@ object MacroRepImpls{
                                                       (repeater: c.Tree,
                                                        whitespace: c.Tree,
                                                        ctx: c.Tree): c.Tree = {
-    import c.universe._
     MacroRepImpls.repXMacro0[T, V](c)(Some(whitespace), Some(min))(repeater, ctx)
   }
 }

--- a/fastparse/src-2/fastparse/package.scala
+++ b/fastparse/src-2/fastparse/package.scala
@@ -284,7 +284,6 @@ package object fastparse extends fastparse.SharedPackageDefs {
       val startTerminals = ctx.terminalMsgs
       parse0()
       ctx.noDropBuffer = oldNoCut
-      val msg = ctx.shortMsg
 
       val res =
         if (ctx.isSuccess) ctx.freshFailure(startPos)
@@ -320,7 +319,6 @@ package object fastparse extends fastparse.SharedPackageDefs {
     ctx.noDropBuffer = true
     parse
     ctx.noDropBuffer = oldNoCut
-    val msg = ctx.shortMsg
 
     val res =
       if (ctx.isSuccess) ctx.freshSuccessUnit(startPos)

--- a/fastparse/src-3/fastparse/internal/MacroInlineImpls.scala
+++ b/fastparse/src-3/fastparse/internal/MacroInlineImpls.scala
@@ -345,7 +345,7 @@ object MacroInlineImpls {
             output.append(Left(s(i)))
           case '-' =>
             i += 1
-            val Left(last) = output.remove(output.length - 1)
+            val Left(last) = output.remove(output.length - 1) : @unchecked
             output.append(Right((last, s(i))))
           case c => output.append(Left(c))
         }

--- a/fastparse/src/fastparse/ParsingRun.scala
+++ b/fastparse/src/fastparse/ParsingRun.scala
@@ -1,6 +1,6 @@
 package fastparse
 
-import fastparse.internal.{Instrument, Lazy, Msgs, Util}
+import fastparse.internal.{Instrument, Msgs}
 
 /**
   * Models an in-progress parsing run; contains all the mutable state that may
@@ -40,7 +40,7 @@ import fastparse.internal.{Instrument, Lazy, Msgs, Util}
   *                         `P(...)` parser.
   * @param terminalMsgs When tracing is enabled, this collects up all the
   *                         upper-most failures that happen at [[traceIndex]]
-  *                         (in [[Lazy]] wrappers) so they can be shown to the
+  *                         (in [[fastparse.internal.Lazy]] wrappers) so they can be shown to the
   *                         user at end-of-parse as suggestions for what could
   *                         make the parse succeed. For terminal parsers like
   *                         [[LiteralStr]], it just aggregate's the string
@@ -60,7 +60,7 @@ import fastparse.internal.{Instrument, Lazy, Msgs, Util}
   *                         we only aggregate the portion of the parser msg
   *                         that takes place after `traceIndex`
   * @param failureStack     The stack of named `P(...)` parsers in effect when
-  *                         the failure occured; only constructed when tracing
+  *                         the failure occurred; only constructed when tracing
   *                         is enabled via `traceIndex != -1`
   * @param isSuccess        Whether or not the parse is currently successful
   * @param logDepth         How many nested `.log` calls are currently surrounding us.
@@ -316,7 +316,7 @@ final class ParsingRun[+T](val input: ParserInput,
     this.asInstanceOf[ParsingRun[Nothing]]
   }
 
-  def checkForDrop() = !noDropBuffer && cut
+  def checkForDrop(): Boolean = !noDropBuffer && cut
 }
 
 object ParsingRun{

--- a/fastparse/src/fastparse/Whitespace.scala
+++ b/fastparse/src/fastparse/Whitespace.scala
@@ -1,6 +1,5 @@
 package fastparse
 
-import fastparse._
 import fastparse.internal.{Msgs, Util}
 
 import scala.annotation.{switch, tailrec}

--- a/fastparse/test/src/fastparse/ExampleTests.scala
+++ b/fastparse/test/src/fastparse/ExampleTests.scala
@@ -3,11 +3,13 @@ package test.fastparse
 import utest._
 import fastparse._
 import fastparse.internal.Logger
+
+import scala.annotation.nowarn
 /**
   * Demonstrates simultaneously parsing and
   * evaluating simple arithmetic expressions
   */
-@fastparse.internal.NoWarn.nowarn("msg=comparing values of types Unit and Unit using `==` will always yield true")
+@nowarn("msg=comparing values of types Unit and Unit using `==` will always yield true")
 object ExampleTests extends TestSuite{
   import fastparse.NoWhitespace._
   val tests = Tests{
@@ -17,6 +19,7 @@ object ExampleTests extends TestSuite{
         def parseA[$: P] = P("a")
 
         val Parsed.Success(value, successIndex) = parse("a", parseA(_))
+
         assert(value == (), successIndex == 1)
 
         val f @ Parsed.Failure(label, index, extra) = parse("b", parseA(_))

--- a/pythonparse/src/pythonparse/Statements.scala
+++ b/pythonparse/src/pythonparse/Statements.scala
@@ -136,7 +136,7 @@ class Statements(indent: Int){
     def lastElse = P( (space_indents ~~ kw("else") ~/ ":" ~~ suite).? )
     P( firstIf ~~ elifs ~~ lastElse ).map{
       case (test, body, elifs, orelse) =>
-        val (init :+ last) = (test, body) +: elifs
+        val (init :+ last) = (test, body) +: elifs : @unchecked
         val (last_test, last_body) = last
         init.foldRight(Ast.stmt.If(last_test, last_body, orelse.toSeq.flatten)){
           case ((test, body), rhs) => Ast.stmt.If(test, body, Seq(rhs))


### PR DESCRIPTION
Motivation:
Enable unused lint for fastparse

Modification:
Some straightforward changing to make compiler happy

Result:
less warning when comping.