### PR TITLE
Update basic examples for Scala 3.5 and later

### DIFF
--- a/readme/WritingParsers.scalatex
+++ b/readme/WritingParsers.scalatex
@@ -13,7 +13,7 @@
             Such a parser returns a @hl.scala{Parsed.Success} if the input matches the string, and otherwise returns a @hl.scala{Parsed.Failure}.
 
         @p
-	   @b{Note}: if using Scala 3.5 or later, calls to the @code{parse} function should include the keyword @code{using}, e.g. @code{parse("a", parseA(using _))}.
+            @b{Note}: if using Scala 3.5 or later, calls to the @code{parse} function should include the keyword @code{using}, e.g. @code{parse("a", parseA(using _))}.
 
         @p
             As you can see, by default the @hl.scala{Parsed.Success} contains

--- a/readme/WritingParsers.scalatex
+++ b/readme/WritingParsers.scalatex
@@ -11,6 +11,10 @@
 
         @p
             Such a parser returns a @hl.scala{Parsed.Success} if the input matches the string, and otherwise returns a @hl.scala{Parsed.Failure}.
+
+        @p
+	   @b{Note}: if using Scala 3.5 or later, calls to the @code{parse} function should include the keyword @code{using}, e.g. @code{parse("a", parseA(using _))}.
+
         @p
             As you can see, by default the @hl.scala{Parsed.Success} contains
             a @hl.scala{(): Unit}, unless you use @sect.ref{Capture} or


### PR DESCRIPTION
solves https://github.com/com-lihaoyi/fastparse/issues/320

Basic examples run into error `No given instance of type
fastparse.ParsingRun[$]` since Scala 3.5. This can be manually worked
around by replacing `parse("a", parseA(_))` with `parse("a", using _)`
since a using keyword now appears to be required.